### PR TITLE
feat: support stdin input with '-' argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # qrrun
 Tunnel local code. Run via QR.
 
+## Usage
+
+Run with a local file:
+
+```bash
+qrrun --transport cloudflared --runtime pythonista3 hello.py
+```
+
+Run from stdin (`-`):
+
+```bash
+echo "print('hello from stdin')" | qrrun --transport cloudflared --runtime pythonista3 -
+```
+
 ## Development Setup (gvm)
 
 This project uses Go `1.24.13`.

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -4,6 +4,7 @@
 // Usage:
 //
 //	qrrun --transport cloudflared --runtime pythonista3 your-local-script.py
+//	echo "print('hello')" | qrrun --transport cloudflared --runtime pythonista3 -
 package main
 
 import (
@@ -27,7 +28,7 @@ func newRootCmd() *cobra.Command {
 	var runtimeName string
 
 	cmd := &cobra.Command{
-		Use:   "qrrun [flags] <script>",
+		Use:   "qrrun [flags] <script|-]",
 		Short: "Tunnel local code. Run via QR.",
 		Long: `qrrun serves a local script over a secure tunnel and displays a QR code.
 
@@ -35,7 +36,8 @@ Scan the QR code with your mobile device to open the script in the configured
 runtime (e.g. Pythonista 3 on iOS).
 
 Examples:
-  qrrun --transport cloudflared --runtime pythonista3 hello.py`,
+	qrrun --transport cloudflared --runtime pythonista3 hello.py
+	echo "print('hello')" | qrrun --transport cloudflared --runtime pythonista3 -`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.Run(app.Options{

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -22,6 +22,7 @@ type Options struct {
 	TransportName string
 	RuntimeName   string
 	ScriptPath    string
+	Input         io.Reader // source for script content when ScriptPath is "-"; defaults to os.Stdin
 	Output        io.Writer // destination for the QR code; defaults to os.Stdout
 }
 
@@ -32,6 +33,9 @@ type Options struct {
 //  4. Prints the QR code to opts.Output once the public URL is known.
 //  5. Blocks until the process receives SIGINT / SIGTERM.
 func Run(opts Options) error {
+	if opts.Input == nil {
+		opts.Input = os.Stdin
+	}
 	if opts.Output == nil {
 		opts.Output = os.Stdout
 	}
@@ -46,7 +50,17 @@ func Run(opts Options) error {
 		return err
 	}
 
-	srv, err := server.New(opts.ScriptPath)
+	scriptPath := opts.ScriptPath
+	cleanup := func() {}
+	if opts.ScriptPath == "-" {
+		scriptPath, cleanup, err = materializeStdinScript(opts.Input)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+	}
+
+	srv, err := server.New(scriptPath)
 	if err != nil {
 		return err
 	}
@@ -106,6 +120,28 @@ func Run(opts Options) error {
 		}
 	}
 	return nil
+}
+
+func materializeStdinScript(input io.Reader) (string, func(), error) {
+	tmpFile, err := os.CreateTemp("", "qrrun-stdin-*.py")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp script: %w", err)
+	}
+
+	if _, err := io.Copy(tmpFile, input); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+		return "", nil, fmt.Errorf("read stdin: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpFile.Name())
+		return "", nil, fmt.Errorf("close temp script: %w", err)
+	}
+
+	cleanup := func() {
+		_ = os.Remove(tmpFile.Name())
+	}
+	return tmpFile.Name(), cleanup, nil
 }
 
 // replaceBase swaps the local base URL in rawURL with publicBase.

--- a/internal/app/stdin_test.go
+++ b/internal/app/stdin_test.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type errorReader struct{}
+
+func (errorReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("read error")
+}
+
+func TestMaterializeStdinScript(t *testing.T) {
+	path, cleanup, err := materializeStdinScript(strings.NewReader("print('ok')\n"))
+	if err != nil {
+		t.Fatalf("materializeStdinScript: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read temp file: %v", err)
+	}
+	if string(content) != "print('ok')\n" {
+		t.Fatalf("unexpected content: %q", string(content))
+	}
+	if filepath.Ext(path) != ".py" {
+		t.Fatalf("expected .py extension, got %q", path)
+	}
+}
+
+func TestMaterializeStdinScript_ReadError(t *testing.T) {
+	path, cleanup, err := materializeStdinScript(errorReader{})
+	if err == nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		t.Fatal("expected read error")
+	}
+	if path != "" {
+		t.Fatalf("expected empty path on error, got %q", path)
+	}
+	if cleanup != nil {
+		t.Fatal("expected nil cleanup on error")
+	}
+}


### PR DESCRIPTION
## Summary
- add support for reading script content from stdin when script path is `-`
- keep existing file-path workflow unchanged by materializing stdin to a temporary script file
- update CLI help/usage and README examples for stdin usage
- add tests for stdin materialization behavior and error handling

## Validation
- go test ./...
- go build ./cmd/qrrun
