### PR TITLE
fix: align quick tunnel behavior and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # qrrun
 Tunnel local code. Run via QR.
 
+## Prerequisites
+
+- `cloudflared` must be installed and available in your PATH.
+- `qrrun` uses Cloudflare Quick Tunnels:
+	https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/
+
 ## Usage
 
 Run with a local file:

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -35,6 +35,11 @@ func newRootCmd() *cobra.Command {
 Scan the QR code with your mobile device to open the script in the configured
 runtime (e.g. Pythonista 3 on iOS).
 
+Prerequisite:
+	cloudflared must be installed and available on PATH.
+	qrrun uses Cloudflare Quick Tunnels (trycloudflare.com),
+	so account login is not required.
+
 Examples:
 	qrrun --transport cloudflared --runtime pythonista3 hello.py
 	echo "print('hello')" | qrrun --transport cloudflared --runtime pythonista3 -`,

--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -4,15 +4,17 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"regexp"
+	"sync"
 )
 
 // Cloudflared uses the cloudflared quick-tunnel feature to expose a local URL.
 // The cloudflared binary must be available on PATH.
 type Cloudflared struct{}
 
-// tunnelURLRe matches the public URL printed by cloudflared to stderr.
+// tunnelURLRe matches the public URL printed by cloudflared logs.
 var tunnelURLRe = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 
 // Expose starts a cloudflared quick tunnel pointing at localURL and sends the
@@ -21,7 +23,12 @@ var tunnelURLRe = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 func (c *Cloudflared) Expose(ctx context.Context, localURL string, urlCh chan<- string) error {
 	cmd := exec.CommandContext(ctx, "cloudflared", "tunnel", "--url", localURL)
 
-	// cloudflared writes its tunnel URL to stderr.
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("cloudflared: pipe stdout: %w", err)
+	}
+
+	// cloudflared usually writes logs to stderr, but this may vary by version.
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		return fmt.Errorf("cloudflared: pipe stderr: %w", err)
@@ -31,15 +38,59 @@ func (c *Cloudflared) Expose(ctx context.Context, localURL string, urlCh chan<- 
 		return fmt.Errorf("cloudflared: start: %w (is cloudflared installed?)", err)
 	}
 
-	urlSent := false
-	scanner := bufio.NewScanner(stderr)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !urlSent {
-			if m := tunnelURLRe.FindString(line); m != "" {
-				urlCh <- m
-				urlSent = true
+	foundURLCh := make(chan string, 1)
+
+	scanOutput := func(r io.Reader) {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			if m := tunnelURLRe.FindString(scanner.Text()); m != "" {
+				select {
+				case foundURLCh <- m:
+				default:
+				}
+				return
 			}
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		scanOutput(stdout)
+	}()
+	go func() {
+		defer wg.Done()
+		scanOutput(stderr)
+	}()
+
+	scanDoneCh := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(scanDoneCh)
+	}()
+
+	urlSent := false
+waitURL:
+	for {
+		select {
+		case u := <-foundURLCh:
+			urlCh <- u
+			urlSent = true
+			break waitURL
+		case <-scanDoneCh:
+			// Best-effort final read in case URL and completion raced.
+			select {
+			case u := <-foundURLCh:
+				urlCh <- u
+				urlSent = true
+			default:
+			}
+			break waitURL
+		case <-ctx.Done():
+			_ = cmd.Wait()
+			<-scanDoneCh
+			return nil
 		}
 	}
 
@@ -49,6 +100,11 @@ func (c *Cloudflared) Expose(ctx context.Context, localURL string, urlCh chan<- 
 			return nil
 		}
 		return fmt.Errorf("cloudflared: exited unexpectedly: %w", err)
+	}
+	<-scanDoneCh
+
+	if !urlSent {
+		return fmt.Errorf("cloudflared: quick tunnel URL not found in output")
 	}
 	return nil
 }

--- a/internal/transport/cloudflared_test.go
+++ b/internal/transport/cloudflared_test.go
@@ -1,0 +1,25 @@
+package transport
+
+import "testing"
+
+func TestTunnelURLRe_Match(t *testing.T) {
+	line := "INF +--------------------------------------------------------------------------------------------+ https://fancy-moon-1234.trycloudflare.com"
+	got := tunnelURLRe.FindString(line)
+	want := "https://fancy-moon-1234.trycloudflare.com"
+	if got != want {
+		t.Fatalf("unexpected URL match: got %q, want %q", got, want)
+	}
+}
+
+func TestTunnelURLRe_NoMatch(t *testing.T) {
+	cases := []string{
+		"https://example.com",
+		"https://foo.trycloudflare.net",
+		"no url here",
+	}
+	for _, line := range cases {
+		if got := tunnelURLRe.FindString(line); got != "" {
+			t.Fatalf("expected no match for %q, got %q", line, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- clarify quick tunnel prerequisite messaging in README and CLI help
- make cloudflared URL detection robust by scanning both stdout and stderr
- handle URL detection/scan completion race safely before returning errors
- add transport tests for trycloudflare URL extraction

## Validation
- go test ./...
- go run ./cmd/qrrun --help
