### PR TITLE
ci: add GitHub Actions checks with gvm setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install gvm
+        shell: bash
+        run: |
+          bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)
+
+      - name: Run checks
+        shell: bash
+        run: |
+          make gvm-setup test lint vet


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow at .github/workflows/ci.yml
- run CI on push to main and on pull requests
- execute make gvm-setup test lint vet in CI

## Notes
- workflow installs gvm before running Make targets
