### PR TITLE
fix: resolve cleanup ineffassign in app run

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -51,8 +51,8 @@ func Run(opts Options) error {
 	}
 
 	scriptPath := opts.ScriptPath
-	cleanup := func() {}
 	if opts.ScriptPath == "-" {
+		var cleanup func()
 		scriptPath, cleanup, err = materializeStdinScript(opts.Input)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- fix ineffassign warning in internal/app/app.go
- remove ineffective default assignment for cleanup function
- keep stdin script materialization behavior unchanged

## Validation
- make gvm-setup test lint vet
