### PR TITLE
feat: add CLI version metadata for alpha release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 BINARY := qrrun
 CMD     := ./cmd/qrrun
 GOLANGCI_LINT_VERSION := v1.64.8
+VERSION ?= v0.1.0-alpha.0
+COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+DATE    := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(DATE)'
 
 ## help: show available make targets
 help:
@@ -16,7 +20,7 @@ gvm-setup:
 
 ## build: compile the binary
 build:
-	go build -o $(BINARY) $(CMD)
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(CMD)
 
 ## test: run all tests
 test:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Run from stdin (`-`):
 echo "print('hello from stdin')" | qrrun --transport cloudflared --runtime pythonista3 -
 ```
 
+Show version:
+
+```bash
+qrrun --version
+```
+
+Current release stage uses Go-style semantic versioning with pre-release tags,
+starting from `v0.1.0-alpha.0`.
+
 ## Development Setup (gvm)
 
 This project uses Go `1.24.13`.

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -16,6 +16,12 @@ import (
 	"github.com/sakurai-youhei/qrrun/internal/app"
 )
 
+var (
+	version = "v0.1.0-alpha.0"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -48,6 +54,9 @@ Examples:
 		},
 		SilenceUsage: true,
 	}
+
+	cmd.Version = fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date)
+	cmd.SetVersionTemplate("{{.Version}}\n")
 
 	cmd.Flags().StringVar(&transportName, "transport", "cloudflared",
 		`Tunnel transport to use. Available: cloudflared`)


### PR DESCRIPTION
## Summary
- add CLI version output via `qrrun --version`
- introduce alpha baseline version: `v0.1.0-alpha.0`
- embed build metadata (`version`, `commit`, `date`) via Makefile ldflags
- document version command and alpha versioning policy in README

## Validation
- go test ./...
- go run ./cmd/qrrun --version
- make build && ./qrrun --version
