### PR TITLE
docs: align README and CLI help wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,29 @@ Tunnel local code. Run via QR.
 ## Prerequisites
 
 - `cloudflared` must be installed and available in your PATH.
-- `qrrun` uses Cloudflare Quick Tunnels:
-	https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/
+- `qrrun` uses Cloudflare Quick Tunnels. For details, see [Cloudflare's Quick Tunnel documentation](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/).
 
 ## Usage
 
 Run with a local file:
 
 ```bash
-qrrun --transport cloudflared --runtime pythonista3 hello.py
+qrrun hello.py
 ```
 
 Run from stdin (`-`):
 
 ```bash
-echo "print('hello from stdin')" | qrrun --transport cloudflared --runtime pythonista3 -
+echo "print('hello from stdin')" | qrrun -
 ```
+
+By default, qrrun generates a QR code for opening and running your script in Pythonista3 via Cloudflare Quick Tunnels, unless you explicitly override `--transport` or `--runtime`.
 
 ## Development Setup (gvm)
 
 This project uses Go `1.24.13`.
 
-1. Install gvm (Go Version Manager) by following the official guide:
-
-https://github.com/moovweb/gvm?tab=readme-ov-file#installing
+1. Install gvm (Go Version Manager) by following the [official installation guide](https://github.com/moovweb/gvm?tab=readme-ov-file#installing).
 
 2. Install the required Go version and activate it:
 

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -3,8 +3,8 @@
 //
 // Usage:
 //
-//	qrrun --transport cloudflared --runtime pythonista3 your-local-script.py
-//	echo "print('hello')" | qrrun --transport cloudflared --runtime pythonista3 -
+//	qrrun your-local-script.py
+//	echo "print('hello')" | qrrun -
 package main
 
 import (
@@ -39,10 +39,13 @@ Prerequisite:
 	cloudflared must be installed and available on PATH.
 	qrrun uses Cloudflare Quick Tunnels (trycloudflare.com),
 	so account login is not required.
+	By default, qrrun generates a QR code for opening and running your
+	script in Pythonista3 via Cloudflare Quick Tunnels, unless you
+	explicitly override "--transport" or "--runtime".
 
 Examples:
-	qrrun --transport cloudflared --runtime pythonista3 hello.py
-	echo "print('hello')" | qrrun --transport cloudflared --runtime pythonista3 -`,
+	qrrun hello.py
+	echo "print('hello')" | qrrun -`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return app.Run(app.Options{


### PR DESCRIPTION
## Summary
- simplify README examples by omitting default flags
- align default behavior wording between README and CLI help
- clarify that defaults are cloudflared + pythonista3 unless overridden

## Validation
- go run ./cmd/qrrun --help
