### PR TITLE
fix: support pythonista URL schemes and prevent test hang

### DIFF
--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -57,7 +57,7 @@ Examples:
 	cmd.Flags().StringVar(&transportName, "transport", "cloudflared",
 		`Tunnel transport to use. Available: cloudflared`)
 	cmd.Flags().StringVar(&runtimeName, "runtime", "pythonista3",
-		`Mobile runtime to target. Available: pythonista3`)
+		`Mobile runtime to target. Available: pythonista, pythonista2, pythonista3`)
 
 	return cmd
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -60,6 +60,10 @@ func Run(opts Options) error {
 		defer cleanup()
 	}
 
+	if _, err := os.Stat(scriptPath); err != nil {
+		return fmt.Errorf("script path: %w", err)
+	}
+
 	srv, err := server.New(scriptPath)
 	if err != nil {
 		return err

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -32,14 +32,14 @@ func TestRun_InvalidRuntime(t *testing.T) {
 }
 
 func TestRun_InvalidScriptPath(t *testing.T) {
-	// server.New will fail if the directory doesn't exist
+	// app.Run now validates script existence before starting transport.
 	err := app.Run(app.Options{
 		TransportName: "cloudflared",
 		RuntimeName:   "pythonista3",
 		ScriptPath:    "/nonexistent/path/script.py",
 		Output:        io.Discard,
 	})
-	// server.New does not stat the file so it won't fail here;
-	// just verify transport/runtime validation passes without panic.
-	_ = err
+	if err == nil {
+		t.Fatal("expected error for invalid script path")
+	}
 }

--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -1,20 +1,19 @@
 package runtime
 
-import "net/url"
+import (
+	"fmt"
+	"net/url"
+)
 
-// Pythonista3 produces URLs for the Pythonista 3 iOS app.
-// The URL scheme pythonista3://importscript?url=<script-url>&name=<filename>
-// instructs the app to import and run the remote script.
-type Pythonista3 struct{}
+// Pythonista produces URLs for Pythonista runtimes.
+// It embeds Python code via the `exec` URL parameter.
+type Pythonista struct {
+	Scheme string
+}
 
 // QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
-func (p *Pythonista3) QRCodeURL(publicURL string) string {
-	u := url.URL{
-		Scheme: "pythonista3",
-		Host:   "importscript",
-		RawQuery: url.Values{
-			"url": []string{publicURL},
-		}.Encode(),
-	}
-	return u.String()
+func (p *Pythonista) QRCodeURL(publicURL string) string {
+	code := fmt.Sprintf("import urllib.request\nexec(urllib.request.urlopen(%q).read().decode('utf-8'))", publicURL)
+	q := url.Values{"exec": []string{code}}.Encode()
+	return fmt.Sprintf("%s://?%s", p.Scheme, q)
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -20,9 +20,13 @@ type Runtime interface {
 // unknown.
 func New(name string) (Runtime, error) {
 	switch name {
+	case "pythonista":
+		return &Pythonista{Scheme: "pythonista"}, nil
+	case "pythonista2":
+		return &Pythonista{Scheme: "pythonista2"}, nil
 	case "pythonista3":
-		return &Pythonista3{}, nil
+		return &Pythonista{Scheme: "pythonista3"}, nil
 	default:
-		return nil, fmt.Errorf("unknown runtime %q (available: pythonista3)", name)
+		return nil, fmt.Errorf("unknown runtime %q (available: pythonista, pythonista2, pythonista3)", name)
 	}
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -8,12 +9,15 @@ import (
 )
 
 func TestNew_KnownRuntime(t *testing.T) {
-	rt, err := runtime.New("pythonista3")
-	if err != nil {
-		t.Fatalf("unexpected error for known runtime: %v", err)
-	}
-	if rt == nil {
-		t.Fatal("expected non-nil Runtime")
+	known := []string{"pythonista", "pythonista2", "pythonista3"}
+	for _, name := range known {
+		rt, err := runtime.New(name)
+		if err != nil {
+			t.Fatalf("unexpected error for known runtime %q: %v", name, err)
+		}
+		if rt == nil {
+			t.Fatalf("expected non-nil Runtime for %q", name)
+		}
 	}
 }
 
@@ -24,25 +28,43 @@ func TestNew_UnknownRuntime(t *testing.T) {
 	}
 }
 
-func TestPythonista3_QRCodeURL(t *testing.T) {
-	rt, err := runtime.New("pythonista3")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
+	tests := []struct {
+		name   string
+		scheme string
+	}{
+		{name: "pythonista", scheme: "pythonista"},
+		{name: "pythonista2", scheme: "pythonista2"},
+		{name: "pythonista3", scheme: "pythonista3"},
 	}
 
 	rawURL := "https://example.trycloudflare.com/hello.py"
-	got := rt.QRCodeURL(rawURL)
 
-	if !strings.HasPrefix(got, "pythonista3://") {
-		t.Errorf("expected pythonista3:// scheme, got %q", got)
-	}
-	if !strings.Contains(got, "importscript") {
-		t.Errorf("expected importscript host, got %q", got)
-	}
-	if !strings.Contains(got, "url=") {
-		t.Errorf("expected url= query param, got %q", got)
-	}
-	if !strings.Contains(got, "example.trycloudflare.com") {
-		t.Errorf("expected original host in URL, got %q", got)
+	for _, tc := range tests {
+		rt, err := runtime.New(tc.name)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", tc.name, err)
+		}
+
+		got := rt.QRCodeURL(rawURL)
+		if !strings.HasPrefix(got, tc.scheme+"://") {
+			t.Errorf("expected %s:// scheme, got %q", tc.scheme, got)
+		}
+
+		u, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse url for %q: %v", tc.name, err)
+		}
+
+		execCode := u.Query().Get("exec")
+		if execCode == "" {
+			t.Errorf("expected exec query parameter for %q, got %q", tc.name, got)
+		}
+		if !strings.Contains(execCode, "urllib.request.urlopen") {
+			t.Errorf("expected urllib.request.urlopen in exec code for %q, got %q", tc.name, execCode)
+		}
+		if !strings.Contains(execCode, rawURL) {
+			t.Errorf("expected raw URL in exec code for %q, got %q", tc.name, execCode)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- switch Pythonista runtime URLs to `?exec=<code>` format
- support `--runtime pythonista`, `--runtime pythonista2`, and `--runtime pythonista3`
- update runtime tests for all three Pythonista schemes
- prevent `go test ./...` hang by validating script path existence before starting transport
- update app test expectation for invalid script path

## Validation
- go test -v -count=1 -timeout=120s ./...
