### PR TITLE
Do not URL-encode pythonista exec query

### DIFF
--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -2,7 +2,6 @@ package runtime
 
 import (
 	"fmt"
-	"net/url"
 )
 
 // Pythonista produces URLs for Pythonista runtimes.
@@ -14,6 +13,5 @@ type Pythonista struct {
 // QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
 func (p *Pythonista) QRCodeURL(publicURL string) string {
 	code := fmt.Sprintf("import urllib.request\nexec(urllib.request.urlopen(%q).read().decode('utf-8'))", publicURL)
-	q := url.Values{"exec": []string{code}}.Encode()
-	return fmt.Sprintf("%s://?%s", p.Scheme, q)
+	return fmt.Sprintf("%s://?exec=%s", p.Scheme, code)
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,7 +1,6 @@
 package runtime_test
 
 import (
-	"net/url"
 	"strings"
 	"testing"
 
@@ -51,12 +50,12 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 			t.Errorf("expected %s:// scheme, got %q", tc.scheme, got)
 		}
 
-		u, err := url.Parse(got)
-		if err != nil {
-			t.Fatalf("parse url for %q: %v", tc.name, err)
+		prefix := tc.scheme + "://?exec="
+		if !strings.HasPrefix(got, prefix) {
+			t.Errorf("expected %q prefix for %q, got %q", prefix, tc.name, got)
 		}
 
-		execCode := u.Query().Get("exec")
+		execCode := strings.TrimPrefix(got, prefix)
 		if execCode == "" {
 			t.Errorf("expected exec query parameter for %q, got %q", tc.name, got)
 		}
@@ -65,6 +64,9 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		}
 		if !strings.Contains(execCode, rawURL) {
 			t.Errorf("expected raw URL in exec code for %q, got %q", tc.name, execCode)
+		}
+		if strings.Contains(execCode, "%") {
+			t.Errorf("expected unencoded exec code for %q, got %q", tc.name, execCode)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- stop URL-encoding the Pythonista exec query payload
- build the deep-link as pythonista://?exec=<raw code>
- update runtime tests to assert unencoded exec content

## Verification
- go test ./...