### PR TITLE
Serve scripts from memory with UUID endpoint

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -50,21 +50,12 @@ func Run(opts Options) error {
 		return err
 	}
 
-	scriptPath := opts.ScriptPath
-	if opts.ScriptPath == "-" {
-		var cleanup func()
-		scriptPath, cleanup, err = materializeStdinScript(opts.Input)
-		if err != nil {
-			return err
-		}
-		defer cleanup()
+	scriptBytes, err := loadScriptContent(opts.ScriptPath, opts.Input)
+	if err != nil {
+		return err
 	}
 
-	if _, err := os.Stat(scriptPath); err != nil {
-		return fmt.Errorf("script path: %w", err)
-	}
-
-	srv, err := server.New(scriptPath)
+	srv, err := server.New(scriptBytes, "text/x-python; charset=utf-8")
 	if err != nil {
 		return err
 	}
@@ -126,26 +117,20 @@ func Run(opts Options) error {
 	return nil
 }
 
-func materializeStdinScript(input io.Reader) (string, func(), error) {
-	tmpFile, err := os.CreateTemp("", "qrrun-stdin-*.py")
+func loadScriptContent(scriptPath string, input io.Reader) ([]byte, error) {
+	if scriptPath == "-" {
+		b, err := io.ReadAll(input)
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+		return b, nil
+	}
+
+	b, err := os.ReadFile(scriptPath)
 	if err != nil {
-		return "", nil, fmt.Errorf("create temp script: %w", err)
+		return nil, fmt.Errorf("script path: %w", err)
 	}
-
-	if _, err := io.Copy(tmpFile, input); err != nil {
-		_ = tmpFile.Close()
-		_ = os.Remove(tmpFile.Name())
-		return "", nil, fmt.Errorf("read stdin: %w", err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		_ = os.Remove(tmpFile.Name())
-		return "", nil, fmt.Errorf("close temp script: %w", err)
-	}
-
-	cleanup := func() {
-		_ = os.Remove(tmpFile.Name())
-	}
-	return tmpFile.Name(), cleanup, nil
+	return b, nil
 }
 
 // replaceBase swaps the local base URL in rawURL with publicBase.

--- a/internal/app/stdin_test.go
+++ b/internal/app/stdin_test.go
@@ -3,7 +3,6 @@ package app
 import (
 	"errors"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -14,37 +13,54 @@ func (errorReader) Read(_ []byte) (int, error) {
 	return 0, errors.New("read error")
 }
 
-func TestMaterializeStdinScript(t *testing.T) {
-	path, cleanup, err := materializeStdinScript(strings.NewReader("print('ok')\n"))
+func TestLoadScriptContent_FromStdin(t *testing.T) {
+	content, err := loadScriptContent("-", strings.NewReader("print('ok')\n"))
 	if err != nil {
-		t.Fatalf("materializeStdinScript: %v", err)
-	}
-	t.Cleanup(cleanup)
-
-	content, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read temp file: %v", err)
+		t.Fatalf("loadScriptContent: %v", err)
 	}
 	if string(content) != "print('ok')\n" {
 		t.Fatalf("unexpected content: %q", string(content))
 	}
-	if filepath.Ext(path) != ".py" {
-		t.Fatalf("expected .py extension, got %q", path)
+}
+
+func TestLoadScriptContent_StdinReadError(t *testing.T) {
+	content, err := loadScriptContent("-", errorReader{})
+	if err == nil {
+		t.Fatal("expected read error")
+	}
+	if content != nil {
+		t.Fatalf("expected nil content on error, got %q", string(content))
+	}
+	if !strings.Contains(err.Error(), "read stdin") {
+		t.Fatalf("expected read stdin error, got %v", err)
 	}
 }
 
-func TestMaterializeStdinScript_ReadError(t *testing.T) {
-	path, cleanup, err := materializeStdinScript(errorReader{})
+func TestLoadScriptContent_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/hello.py"
+	if err := os.WriteFile(path, []byte("print('file')\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	content, err := loadScriptContent(path, strings.NewReader("ignored"))
+	if err != nil {
+		t.Fatalf("loadScriptContent: %v", err)
+	}
+	if string(content) != "print('file')\n" {
+		t.Fatalf("unexpected content: %q", string(content))
+	}
+}
+
+func TestLoadScriptContent_FileReadError(t *testing.T) {
+	content, err := loadScriptContent("/nonexistent/path/script.py", strings.NewReader("ignored"))
 	if err == nil {
-		if cleanup != nil {
-			cleanup()
-		}
-		t.Fatal("expected read error")
+		t.Fatal("expected script path error")
 	}
-	if path != "" {
-		t.Fatalf("expected empty path on error, got %q", path)
+	if content != nil {
+		t.Fatalf("expected nil content on error, got %q", string(content))
 	}
-	if cleanup != nil {
-		t.Fatal("expected nil cleanup on error")
+	if !strings.Contains(err.Error(), "script path") {
+		t.Fatalf("expected script path error, got %v", err)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,27 +3,42 @@
 package server
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"context"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"path/filepath"
 )
 
-// Server is a single-file HTTP server.
+// Server is an in-memory single-script HTTP server.
 type Server struct {
-	scriptPath string
-	listener   net.Listener
+	scriptID    string
+	scriptBytes []byte
+	contentType string
+	listener    net.Listener
 }
 
-// New creates a Server that serves scriptPath on a random free port.
-func New(scriptPath string) (*Server, error) {
+// New creates a Server that serves scriptBytes on a random free port.
+// The script is exposed at /<uuid-without-extension>.
+func New(scriptBytes []byte, contentType string) (*Server, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("server: listen: %w", err)
 	}
-	return &Server{scriptPath: scriptPath, listener: ln}, nil
+
+	scriptID, err := newScriptID()
+	if err != nil {
+		return nil, fmt.Errorf("server: script id: %w", err)
+	}
+
+	return &Server{
+		scriptID:    scriptID,
+		scriptBytes: scriptBytes,
+		contentType: contentType,
+		listener:    ln,
+	}, nil
 }
 
 // URL returns the base URL of this server (e.g. "http://127.0.0.1:54321").
@@ -33,14 +48,27 @@ func (s *Server) URL() string {
 
 // ScriptURL returns the full URL for the served script file.
 func (s *Server) ScriptURL() string {
-	return s.URL() + "/" + filepath.Base(s.scriptPath)
+	return s.URL() + "/" + s.scriptID
 }
 
 // Serve starts the HTTP server and blocks until ctx is cancelled or an
 // unrecoverable error occurs.
 func (s *Server) Serve(ctx context.Context) error {
 	mux := http.NewServeMux()
-	mux.Handle("/"+filepath.Base(s.scriptPath), http.FileServer(http.Dir(filepath.Dir(s.scriptPath))))
+	mux.HandleFunc("/"+s.scriptID, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", s.contentType)
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(s.scriptBytes)))
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, _ = w.Write(s.scriptBytes)
+	})
 
 	srv := &http.Server{Handler: mux}
 
@@ -61,4 +89,13 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 		return fmt.Errorf("server: serve: %w", err)
 	}
+}
+
+func newScriptID() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	// 32 hex chars, extensionless UUID-like identifier suitable for URL path.
+	return hex.EncodeToString(raw), nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,9 +3,9 @@
 package server
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"context"
 	"errors"
 	"fmt"
 	"net"

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -15,15 +14,8 @@ import (
 )
 
 func TestServer_ServesScriptFile(t *testing.T) {
-	// Write a temporary script file.
-	dir := t.TempDir()
-	scriptPath := filepath.Join(dir, "hello.py")
 	content := "print('hello')\n"
-	if err := os.WriteFile(scriptPath, []byte(content), 0o644); err != nil {
-		t.Fatalf("write temp file: %v", err)
-	}
-
-	srv, err := server.New(scriptPath)
+	srv, err := server.New([]byte(content), "text/x-python; charset=utf-8")
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -58,16 +50,13 @@ func TestServer_ServesScriptFile(t *testing.T) {
 	if !strings.Contains(string(body), "print") {
 		t.Errorf("unexpected body: %q", string(body))
 	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/x-python; charset=utf-8" {
+		t.Errorf("unexpected Content-Type: %q", ct)
+	}
 }
 
 func TestServer_URLFormat(t *testing.T) {
-	dir := t.TempDir()
-	scriptPath := filepath.Join(dir, "test.py")
-	if err := os.WriteFile(scriptPath, []byte(""), 0o644); err != nil {
-		t.Fatalf("write temp file: %v", err)
-	}
-
-	srv, err := server.New(scriptPath)
+	srv, err := server.New([]byte(""), "text/x-python; charset=utf-8")
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -75,7 +64,17 @@ func TestServer_URLFormat(t *testing.T) {
 	if !strings.HasPrefix(srv.URL(), "http://127.0.0.1:") {
 		t.Errorf("unexpected URL: %q", srv.URL())
 	}
-	if !strings.HasSuffix(srv.ScriptURL(), "/test.py") {
-		t.Errorf("unexpected ScriptURL: %q", srv.ScriptURL())
+
+	scriptURL := srv.ScriptURL()
+	if !strings.HasPrefix(scriptURL, srv.URL()+"/") {
+		t.Errorf("unexpected ScriptURL prefix: %q", scriptURL)
+	}
+
+	id := strings.TrimPrefix(scriptURL, srv.URL()+"/")
+	if strings.Contains(id, ".") {
+		t.Errorf("expected extensionless script id, got %q", id)
+	}
+	if ok, _ := regexp.MatchString("^[a-f0-9]{32}$", id); !ok {
+		t.Errorf("expected 32-char lowercase hex script id, got %q", id)
 	}
 }


### PR DESCRIPTION
## Summary
- stop creating temp files for stdin scripts
- load script content into memory at command start for both stdin and file path input
- serve script bytes directly from memory via an extensionless UUID endpoint
- explicitly return Python MIME type via Content-Type header
- update app/server tests for the new in-memory flow

## Verification
- go test ./...