### PR TITLE
Add tag-triggered cross-platform release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  guard-main:
+    runs-on: ubuntu-latest
+    outputs:
+      on_main: ${{ steps.check.outputs.on_main }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version from tag
+        id: version
+        shell: bash
+        run: |
+          echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tagged commit is on main
+        id: check
+        shell: bash
+        run: |
+          git fetch origin main --depth=1
+          if git merge-base --is-ancestor "$GITHUB_SHA" "origin/main"; then
+            echo "on_main=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "on_main=false" >> "$GITHUB_OUTPUT"
+          echo "Tag ${GITHUB_REF_NAME} is not on main. Skipping release."
+
+  build:
+    runs-on: ubuntu-latest
+    needs: guard-main
+    if: needs.guard-main.outputs.on_main == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ""
+            archive: tar.gz
+          - goos: linux
+            goarch: arm64
+            ext: ""
+            archive: tar.gz
+          - goos: darwin
+            goarch: amd64
+            ext: ""
+            archive: tar.gz
+          - goos: darwin
+            goarch: arm64
+            ext: ""
+            archive: tar.gz
+          - goos: windows
+            goarch: amd64
+            ext: .exe
+            archive: zip
+          - goos: windows
+            goarch: arm64
+            ext: .exe
+            archive: zip
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binary and package
+        shell: bash
+        env:
+          VERSION: ${{ needs.guard-main.outputs.version }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          EXT: ${{ matrix.ext }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          set -euo pipefail
+
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          COMMIT_SHORT="${GITHUB_SHA::7}"
+          BASE="qrrun_${VERSION}_${GOOS}_${GOARCH}"
+          BIN="${BASE}${EXT}"
+
+          mkdir -p dist
+
+          CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+            go build \
+              -trimpath \
+              -ldflags "-s -w -X 'main.version=${VERSION}' -X 'main.commit=${COMMIT_SHORT}' -X 'main.date=${DATE}'" \
+              -o "dist/${BIN}" \
+              ./cmd/qrrun
+
+          if [ "$ARCHIVE" = "zip" ]; then
+            (cd dist && zip -q "${BASE}.zip" "${BIN}")
+          else
+            tar -C dist -czf "dist/${BASE}.tar.gz" "${BIN}"
+          fi
+
+      - name: Upload packaged artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*.tar.gz
+          if-no-files-found: ignore
+
+      - name: Upload packaged artifact (zip)
+        if: matrix.archive == 'zip'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.goos }}-${{ matrix.goarch }}-zip
+          path: dist/*.zip
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - guard-main
+      - build
+    if: needs.guard-main.outputs.on_main == 'true'
+    steps:
+      - name: Download all packaged artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ needs.guard-main.outputs.version }}
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/*.zip


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow triggered by version tags (v*)
- ensure tagged commit belongs to main before releasing
- build binaries for Linux, macOS, and Windows (amd64/arm64)
- embed tag version into ldflags metadata during build
- create GitHub Release and upload packaged artifacts