### PR TITLE
Set make default goal to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: help gvm-setup build test lint vet clean
 
+.DEFAULT_GOAL := build
+
 BINARY := qrrun
 CMD     := ./cmd/qrrun
 GOLANGCI_LINT_VERSION := v1.64.8


### PR DESCRIPTION
## Summary
- set .DEFAULT_GOAL := build in Makefile
- allow plain make to execute the build target by default

## Verification
- run make and confirm it executes go build