### PR TITLE
Improve one-shot shutdown with quiet period and request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ echo "print('hello from stdin')" | qrrun -
 
 By default, qrrun generates a QR code for opening and running your script in Pythonista3 via Cloudflare Quick Tunnels, unless you explicitly override `--transport` or `--runtime`.
 
+By default, qrrun exits after successful content delivery and a short quiet period (`500ms`).
+
+You can tune this with `--exit-quiet-period`:
+
+```bash
+qrrun --exit-quiet-period 300ms hello.py
+```
+
+Keep serving requests until interrupted:
+
+```bash
+qrrun --keep-serving hello.py
+```
+
+Each received request is logged to the console (method/path/remote address), regardless of HTTP verb.
+
 ## Development Setup (gvm)
 
 This project uses Go `1.24.13`.

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -10,6 +10,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -32,6 +33,9 @@ func main() {
 func newRootCmd() *cobra.Command {
 	var transportName string
 	var runtimeName string
+	var keepServing bool
+	var serveMultipleDeprecated bool
+	var exitQuietPeriod time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "qrrun [flags] <script|-]",
@@ -54,10 +58,13 @@ Examples:
 	echo "print('hello')" | qrrun -`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			keepServingMode := keepServing || serveMultipleDeprecated
 			return app.Run(app.Options{
-				TransportName: transportName,
-				RuntimeName:   runtimeName,
-				ScriptPath:    args[0],
+				TransportName:   transportName,
+				RuntimeName:     runtimeName,
+				ScriptPath:      args[0],
+				KeepServing:     keepServingMode,
+				ExitQuietPeriod: exitQuietPeriod,
 			})
 		},
 		SilenceUsage: true,
@@ -70,6 +77,13 @@ Examples:
 		`Tunnel transport to use. Available: cloudflared`)
 	cmd.Flags().StringVar(&runtimeName, "runtime", "pythonista3",
 		`Mobile runtime to target. Available: pythonista, pythonista2, pythonista3`)
+	cmd.Flags().BoolVar(&keepServing, "keep-serving", false,
+		`Keep serving requests until interrupted. By default qrrun exits after successful delivery and a short quiet period.`)
+	cmd.Flags().DurationVar(&exitQuietPeriod, "exit-quiet-period", app.DefaultExitQuietPeriod,
+		`Quiet period before exit in default mode (examples: 300ms, 1s). Ignored when --keep-serving is enabled.`)
+	cmd.Flags().BoolVar(&serveMultipleDeprecated, "serve-multiple", false,
+		`Deprecated alias of --keep-serving.`)
+	_ = cmd.Flags().MarkDeprecated("serve-multiple", "use --keep-serving instead")
 
 	return cmd
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/mdp/qrterminal/v3"
 
@@ -19,12 +20,16 @@ import (
 
 // Options holds the configuration for a single qrrun invocation.
 type Options struct {
-	TransportName string
-	RuntimeName   string
-	ScriptPath    string
-	Input         io.Reader // source for script content when ScriptPath is "-"; defaults to os.Stdin
-	Output        io.Writer // destination for the QR code; defaults to os.Stdout
+	TransportName   string
+	RuntimeName     string
+	ScriptPath      string
+	KeepServing     bool
+	ExitQuietPeriod time.Duration
+	Input           io.Reader // source for script content when ScriptPath is "-"; defaults to os.Stdin
+	Output          io.Writer // destination for the QR code; defaults to os.Stdout
 }
+
+const DefaultExitQuietPeriod = 500 * time.Millisecond
 
 // Run performs the full qrrun workflow:
 //  1. Validates options and resolves the transport / runtime.
@@ -38,6 +43,10 @@ func Run(opts Options) error {
 	}
 	if opts.Output == nil {
 		opts.Output = os.Stdout
+	}
+	quietPeriod := opts.ExitQuietPeriod
+	if quietPeriod <= 0 {
+		quietPeriod = DefaultExitQuietPeriod
 	}
 
 	t, err := transport.New(opts.TransportName)
@@ -55,7 +64,7 @@ func Run(opts Options) error {
 		return err
 	}
 
-	srv, err := server.New(scriptBytes, "text/x-python; charset=utf-8")
+	srv, err := server.New(scriptBytes, "text/x-python; charset=utf-8", os.Stdout)
 	if err != nil {
 		return err
 	}
@@ -100,9 +109,69 @@ func Run(opts Options) error {
 		WhiteChar: qrterminal.WHITE,
 		QuietZone: 1,
 	})
-	fmt.Fprintf(opts.Output, "\nURL: %s\n\nPress Ctrl+C to stop.\n", scriptPublicURL)
+	if opts.KeepServing {
+		fmt.Fprintf(opts.Output, "\nURL: %s\n\nKeep-serving mode enabled. Press Ctrl+C to stop.\n", scriptPublicURL)
+	} else {
+		fmt.Fprintf(opts.Output, "\nURL: %s\n\nDefault mode: qrrun exits after the last successful content delivery (quiet period: %s).\n", scriptPublicURL, quietPeriod)
+	}
 
-	// Block until cancelled.
+	if !opts.KeepServing {
+		// Default mode: wait for successful delivery, then exit after a quiet period.
+		timer := time.NewTimer(24 * time.Hour)
+		timer.Stop()
+		defer timer.Stop()
+		hasDelivery := false
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-srv.DeliveryEvents():
+			hasDelivery = true
+			timer.Reset(quietPeriod)
+		case err := <-serverErrCh:
+			if err != nil {
+				return err
+			}
+			return nil
+		case err := <-transportErrCh:
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-srv.DeliveryEvents():
+				hasDelivery = true
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(quietPeriod)
+			case <-timer.C:
+				if hasDelivery {
+					return nil
+				}
+			case err := <-serverErrCh:
+				if err != nil {
+					return err
+				}
+				return nil
+			case err := <-transportErrCh:
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+		}
+	}
+
+	// Multi-request mode: keep running until cancelled.
 	select {
 	case <-ctx.Done():
 	case err := <-serverErrCh:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,8 +8,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"os"
+	"sync"
 )
 
 // Server is an in-memory single-script HTTP server.
@@ -17,15 +20,22 @@ type Server struct {
 	scriptID    string
 	scriptBytes []byte
 	contentType string
+	requestLog  io.Writer
 	listener    net.Listener
+	firstReqCh  chan struct{}
+	deliveryCh  chan struct{}
+	firstReq    sync.Once
 }
 
 // New creates a Server that serves scriptBytes on a random free port.
 // The script is exposed at /<uuid-without-extension>.
-func New(scriptBytes []byte, contentType string) (*Server, error) {
+func New(scriptBytes []byte, contentType string, requestLog io.Writer) (*Server, error) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, fmt.Errorf("server: listen: %w", err)
+	}
+	if requestLog == nil {
+		requestLog = os.Stdout
 	}
 
 	scriptID, err := newScriptID()
@@ -37,7 +47,10 @@ func New(scriptBytes []byte, contentType string) (*Server, error) {
 		scriptID:    scriptID,
 		scriptBytes: scriptBytes,
 		contentType: contentType,
+		requestLog:  requestLog,
 		listener:    ln,
+		firstReqCh:  make(chan struct{}),
+		deliveryCh:  make(chan struct{}, 32),
 	}, nil
 }
 
@@ -51,11 +64,22 @@ func (s *Server) ScriptURL() string {
 	return s.URL() + "/" + s.scriptID
 }
 
+// FirstRequestServed is closed once the script endpoint is served for the first time.
+func (s *Server) FirstRequestServed() <-chan struct{} {
+	return s.firstReqCh
+}
+
+// DeliveryEvents receives an event each time script content is successfully written.
+func (s *Server) DeliveryEvents() <-chan struct{} {
+	return s.deliveryCh
+}
+
 // Serve starts the HTTP server and blocks until ctx is cancelled or an
 // unrecoverable error occurs.
 func (s *Server) Serve(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/"+s.scriptID, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(s.requestLog, "request: method=%s path=%s remote=%s\n", r.Method, r.URL.Path, r.RemoteAddr)
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
@@ -67,7 +91,15 @@ func (s *Server) Serve(ctx context.Context) error {
 		if r.Method == http.MethodHead {
 			return
 		}
-		_, _ = w.Write(s.scriptBytes)
+		if _, err := w.Write(s.scriptBytes); err == nil {
+			s.firstReq.Do(func() {
+				close(s.firstReqCh)
+			})
+			select {
+			case s.deliveryCh <- struct{}{}:
+			default:
+			}
+		}
 	})
 
 	srv := &http.Server{Handler: mux}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -15,7 +16,7 @@ import (
 
 func TestServer_ServesScriptFile(t *testing.T) {
 	content := "print('hello')\n"
-	srv, err := server.New([]byte(content), "text/x-python; charset=utf-8")
+	srv, err := server.New([]byte(content), "text/x-python; charset=utf-8", io.Discard)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -56,7 +57,7 @@ func TestServer_ServesScriptFile(t *testing.T) {
 }
 
 func TestServer_URLFormat(t *testing.T) {
-	srv, err := server.New([]byte(""), "text/x-python; charset=utf-8")
+	srv, err := server.New([]byte(""), "text/x-python; charset=utf-8", io.Discard)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -76,5 +77,123 @@ func TestServer_URLFormat(t *testing.T) {
 	}
 	if ok, _ := regexp.MatchString("^[a-f0-9]{32}$", id); !ok {
 		t.Errorf("expected 32-char lowercase hex script id, got %q", id)
+	}
+}
+
+func TestServer_FirstRequestServed_IsSignaled(t *testing.T) {
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", io.Discard)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-srv.FirstRequestServed():
+		t.Fatal("first request signal should not be closed before serving any request")
+	default:
+	}
+
+	resp, err := http.Get(srv.ScriptURL())
+	if err != nil {
+		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case <-srv.FirstRequestServed():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first request signal was not closed after first request")
+	}
+}
+
+func TestServer_FirstRequestServed_HeadDoesNotSignal(t *testing.T) {
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", io.Discard)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	req, err := http.NewRequest(http.MethodHead, srv.ScriptURL(), nil)
+	if err != nil {
+		t.Fatalf("create HEAD request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case <-srv.FirstRequestServed():
+		t.Fatal("first request signal should not be closed by HEAD")
+	default:
+	}
+}
+
+func TestServer_LogsAllRequests(t *testing.T) {
+	var logs bytes.Buffer
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", &logs)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if _, err := http.Get(srv.ScriptURL()); err != nil {
+		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
+	}
+
+	req, err := http.NewRequest(http.MethodHead, srv.ScriptURL(), nil)
+	if err != nil {
+		t.Fatalf("create HEAD request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
+	}
+	_ = resp.Body.Close()
+
+	req, err = http.NewRequest(http.MethodPost, srv.ScriptURL(), strings.NewReader("x"))
+	if err != nil {
+		t.Fatalf("create POST request: %v", err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", srv.ScriptURL(), err)
+	}
+	_ = resp.Body.Close()
+
+	got := logs.String()
+	if !strings.Contains(got, "method=GET") {
+		t.Fatalf("expected GET log, got: %q", got)
+	}
+	if !strings.Contains(got, "method=HEAD") {
+		t.Fatalf("expected HEAD log, got: %q", got)
+	}
+	if !strings.Contains(got, "method=POST") {
+		t.Fatalf("expected POST log, got: %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- log every received request in the internal HTTP server (method/path/remote)
- keep HEAD from triggering one-shot exit semantics
- trigger one-shot completion only after successful content write
- add keep-serving mode semantics and deprecate serve-multiple
- add exit-quiet-period option with a shorter default (500ms)
- update README and CLI descriptions to match behavior

## Verification
- go test ./...
- go run ./cmd/qrrun --help