### PR TITLE
Add pre-commit checks for commit-time quality gates

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,8 @@
+default: true
+
+# Keep line length practical for README code blocks/links.
+MD013:
+  line_length: 140
+
+# Allow duplicate heading text in separate sections when needed.
+MD024: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.14.0
+    hooks:
+      - id: markdownlint-cli2
+
+  - repo: local
+    hooks:
+      - id: gofmt
+        name: gofmt
+        entry: gofmt -w
+        language: system
+        files: \.go$
+
+      - id: go-vet
+        name: go vet
+        entry: go vet ./...
+        language: system
+        pass_filenames: false
+
+      - id: go-test
+        name: go test
+        entry: go test ./...
+        language: system
+        pass_filenames: false
+
+      - id: golangci-lint
+        name: golangci-lint
+        entry: sh -c 'if command -v golangci-lint >/dev/null 2>&1; then golangci-lint run ./...; else go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...; fi'
+        language: system
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help gvm-setup build test lint vet clean
+.PHONY: help gvm-setup build test lint vet pre-commit-install pre-commit-run clean
 
 .DEFAULT_GOAL := build
 
@@ -39,6 +39,14 @@ lint:
 ## vet: run go vet
 vet:
 	go vet ./...
+
+## pre-commit-install: install git pre-commit hooks
+pre-commit-install:
+	pre-commit install
+
+## pre-commit-run: run all pre-commit hooks across all files
+pre-commit-run:
+	pre-commit run --all-files
 
 ## clean: remove build artifacts
 clean:


### PR DESCRIPTION
## Summary
- add pre-commit configuration for common commit-time checks
- include markdown lint and general file hygiene hooks
- run Go formatting/lint/test checks through pre-commit
- add Makefile targets for installing and running pre-commit hooks

## Verification
- go test ./...