### PR TITLE
Add Windows environment to CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,21 @@ jobs:
         shell: bash
         run: |
           make gvm-setup test lint vet
+
+  checks-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run checks
+        shell: bash
+        run: |
+          go test ./...
+          go vet ./...
+          go build ./...


### PR DESCRIPTION
## Summary
- add a windows-latest CI job in addition to the existing ubuntu job
- run go test, go vet, and go build on Windows

## Verification
- go test ./... (local)
- workflow updated in .github/workflows/ci.yml