### PR TITLE
Add platform-specific local origin listener handling

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -82,7 +82,7 @@ func Run(opts Options) error {
 	urlCh := make(chan string, 1)
 	transportErrCh := make(chan error, 1)
 	go func() {
-		transportErrCh <- t.Expose(ctx, srv.URL(), urlCh)
+		transportErrCh <- t.Expose(ctx, srv.OriginURL(), urlCh)
 	}()
 
 	// Wait for the public URL or an early error.

--- a/internal/server/listener_unix.go
+++ b/internal/server/listener_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+func newOriginListener() (net.Listener, string, string, func(), error) {
+	socketDir, err := os.MkdirTemp("", "qrrun-sock-*")
+	if err != nil {
+		return nil, "", "", nil, fmt.Errorf("server: create socket dir: %w", err)
+	}
+	if err := os.Chmod(socketDir, 0o700); err != nil {
+		_ = os.RemoveAll(socketDir)
+		return nil, "", "", nil, fmt.Errorf("server: chmod socket dir: %w", err)
+	}
+
+	socketPath := filepath.Join(socketDir, "origin.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		_ = os.RemoveAll(socketDir)
+		return nil, "", "", nil, fmt.Errorf("server: listen: %w", err)
+	}
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		_ = ln.Close()
+		_ = os.RemoveAll(socketDir)
+		return nil, "", "", nil, fmt.Errorf("server: chmod socket: %w", err)
+	}
+
+	cleanup := func() {
+		_ = os.Remove(socketPath)
+		_ = os.RemoveAll(socketDir)
+	}
+
+	return ln, "http://localhost", "unix://" + socketPath, cleanup, nil
+}

--- a/internal/server/listener_windows.go
+++ b/internal/server/listener_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package server
+
+import (
+	"fmt"
+	"net"
+)
+
+func newOriginListener() (net.Listener, string, string, func(), error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, "", "", nil, fmt.Errorf("server: listen: %w", err)
+	}
+
+	base := "http://" + ln.Addr().String()
+	cleanup := func() {
+		_ = ln.Close()
+	}
+
+	return ln, base, base, cleanup, nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,9 @@ type Server struct {
 	contentType string
 	requestLog  io.Writer
 	listener    net.Listener
+	baseURL     string
+	originURL   string
+	cleanup     func()
 	firstReqCh  chan struct{}
 	deliveryCh  chan struct{}
 	firstReq    sync.Once
@@ -30,9 +33,9 @@ type Server struct {
 // New creates a Server that serves scriptBytes on a random free port.
 // The script is exposed at /<uuid-without-extension>.
 func New(scriptBytes []byte, contentType string, requestLog io.Writer) (*Server, error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, baseURL, originURL, cleanup, err := newOriginListener()
 	if err != nil {
-		return nil, fmt.Errorf("server: listen: %w", err)
+		return nil, err
 	}
 	if requestLog == nil {
 		requestLog = os.Stdout
@@ -49,14 +52,22 @@ func New(scriptBytes []byte, contentType string, requestLog io.Writer) (*Server,
 		contentType: contentType,
 		requestLog:  requestLog,
 		listener:    ln,
+		baseURL:     baseURL,
+		originURL:   originURL,
+		cleanup:     cleanup,
 		firstReqCh:  make(chan struct{}),
 		deliveryCh:  make(chan struct{}, 32),
 	}, nil
 }
 
-// URL returns the base URL of this server (e.g. "http://127.0.0.1:54321").
+// URL returns the local HTTP base URL used for script URL composition.
 func (s *Server) URL() string {
-	return "http://" + s.listener.Addr().String()
+	return s.baseURL
+}
+
+// OriginURL returns the local origin URL for cloudflared.
+func (s *Server) OriginURL() string {
+	return s.originURL
 }
 
 // ScriptURL returns the full URL for the served script file.
@@ -77,6 +88,8 @@ func (s *Server) DeliveryEvents() <-chan struct{} {
 // Serve starts the HTTP server and blocks until ctx is cancelled or an
 // unrecoverable error occurs.
 func (s *Server) Serve(ctx context.Context) error {
+	defer s.cleanup()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/"+s.scriptID, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(s.requestLog, "request: method=%s path=%s remote=%s\n", r.Method, r.URL.Path, r.RemoteAddr)
@@ -122,7 +135,6 @@ func (s *Server) Serve(ctx context.Context) error {
 		return fmt.Errorf("server: serve: %w", err)
 	}
 }
-
 func newScriptID() (string, error) {
 	raw := make([]byte, 16)
 	if _, err := rand.Read(raw); err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -34,7 +36,7 @@ func TestServer_ServesScriptFile(t *testing.T) {
 	// Give the server a moment to start.
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := http.Get(srv.ScriptURL())
+	resp, err := serverHTTPClient(srv.OriginURL()).Get(srv.ScriptURL())
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
@@ -62,8 +64,20 @@ func TestServer_URLFormat(t *testing.T) {
 		t.Fatalf("server.New: %v", err)
 	}
 
-	if !strings.HasPrefix(srv.URL(), "http://127.0.0.1:") {
-		t.Errorf("unexpected URL: %q", srv.URL())
+	if runtime.GOOS == "windows" {
+		if !strings.HasPrefix(srv.URL(), "http://127.0.0.1:") {
+			t.Errorf("unexpected URL: %q", srv.URL())
+		}
+		if !strings.HasPrefix(srv.OriginURL(), "http://127.0.0.1:") {
+			t.Errorf("unexpected OriginURL: %q", srv.OriginURL())
+		}
+	} else {
+		if srv.URL() != "http://localhost" {
+			t.Errorf("unexpected URL: %q", srv.URL())
+		}
+		if !strings.HasPrefix(srv.OriginURL(), "unix://") {
+			t.Errorf("unexpected OriginURL: %q", srv.OriginURL())
+		}
 	}
 
 	scriptURL := srv.ScriptURL()
@@ -101,7 +115,7 @@ func TestServer_FirstRequestServed_IsSignaled(t *testing.T) {
 	default:
 	}
 
-	resp, err := http.Get(srv.ScriptURL())
+	resp, err := serverHTTPClient(srv.OriginURL()).Get(srv.ScriptURL())
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
@@ -133,7 +147,7 @@ func TestServer_FirstRequestServed_HeadDoesNotSignal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create HEAD request: %v", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := serverHTTPClient(srv.OriginURL()).Do(req)
 	if err != nil {
 		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
 	}
@@ -162,7 +176,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	if _, err := http.Get(srv.ScriptURL()); err != nil {
+	if _, err := serverHTTPClient(srv.OriginURL()).Get(srv.ScriptURL()); err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
 
@@ -170,7 +184,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create HEAD request: %v", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := serverHTTPClient(srv.OriginURL()).Do(req)
 	if err != nil {
 		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
 	}
@@ -180,7 +194,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create POST request: %v", err)
 	}
-	resp, err = http.DefaultClient.Do(req)
+	resp, err = serverHTTPClient(srv.OriginURL()).Do(req)
 	if err != nil {
 		t.Fatalf("POST %s: %v", srv.ScriptURL(), err)
 	}
@@ -196,4 +210,17 @@ func TestServer_LogsAllRequests(t *testing.T) {
 	if !strings.Contains(got, "method=POST") {
 		t.Fatalf("expected POST log, got: %q", got)
 	}
+}
+
+func serverHTTPClient(originURL string) *http.Client {
+	if strings.HasPrefix(originURL, "unix://") {
+		socketPath := strings.TrimPrefix(originURL, "unix://")
+		tr := &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			},
+		}
+		return &http.Client{Transport: tr}
+	}
+	return http.DefaultClient
 }

--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os/exec"
 	"regexp"
+	"strings"
 	"sync"
 )
 
@@ -21,7 +22,17 @@ var tunnelURLRe = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 // resulting public URL to urlCh.  It returns when ctx is cancelled or the
 // subprocess exits unexpectedly.
 func (c *Cloudflared) Expose(ctx context.Context, localURL string, urlCh chan<- string) error {
-	cmd := exec.CommandContext(ctx, "cloudflared", "tunnel", "--url", localURL)
+	args := []string{"tunnel"}
+	if strings.HasPrefix(localURL, "unix://") {
+		socketPath := strings.TrimPrefix(localURL, "unix://")
+		args = append(args, "--url", "http://localhost", "--unix-socket", socketPath)
+		fmt.Printf("transport command: cloudflared tunnel --url http://localhost --unix-socket %s\n", socketPath)
+	} else {
+		args = append(args, "--url", localURL)
+		fmt.Printf("transport command: cloudflared tunnel --url %s\n", localURL)
+	}
+
+	cmd := exec.CommandContext(ctx, "cloudflared", args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary
- use platform-specific local origin listeners for internal script serving
- keep unix domain sockets on non-Windows with strict permissions
- add Windows listener fallback for compatibility
- adjust transport and server tests for platform-dependent origin behavior

## Verification
- go test ./...
- GOOS=windows GOARCH=amd64 go build ./...