### PR TITLE
Use requests one-liner in Pythonista QR script

### DIFF
--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -12,6 +12,6 @@ type Pythonista struct {
 
 // QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
 func (p *Pythonista) QRCodeURL(publicURL string) string {
-	code := fmt.Sprintf("import urllib.request\nexec(urllib.request.urlopen(%q).read().decode('utf-8'))", publicURL)
+	code := fmt.Sprintf("import requests as r;exec(r.get(%q).text)", publicURL)
 	return fmt.Sprintf("%s://?exec=%s", p.Scheme, code)
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -59,8 +59,11 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		if execCode == "" {
 			t.Errorf("expected exec query parameter for %q, got %q", tc.name, got)
 		}
-		if !strings.Contains(execCode, "urllib.request.urlopen") {
-			t.Errorf("expected urllib.request.urlopen in exec code for %q, got %q", tc.name, execCode)
+		if !strings.HasPrefix(execCode, "import requests as r;") {
+			t.Errorf("expected requests one-liner prefix in exec code for %q, got %q", tc.name, execCode)
+		}
+		if !strings.Contains(execCode, "exec(r.get(") {
+			t.Errorf("expected r.get execution in exec code for %q, got %q", tc.name, execCode)
 		}
 		if !strings.Contains(execCode, rawURL) {
 			t.Errorf("expected raw URL in exec code for %q, got %q", tc.name, execCode)


### PR DESCRIPTION
## Summary
- change embedded Pythonista exec script to a requests-based one-liner
- start script with import requests as r;
- update runtime tests to match the new one-liner format

## Verification
- go test ./...