### PR TITLE
Align prerequisites wording in README and CLI help

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ Tunnel local code. Run via QR.
 
 ## Prerequisites
 
-- `qrrun` uses Cloudflare Quick Tunnels, so `cloudflared` must be installed and available in your PATH. For details, see [Cloudflare's Quick Tunnel documentation](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/).
+- `cloudflared` must be installed and available in your PATH.
+- `qrrun` uses Cloudflare Quick Tunnels (`trycloudflare.com`).
+
+See [Cloudflare Quick Tunnel documentation](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/) for details.
 
 ## Usage
 

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -45,13 +45,9 @@ func newRootCmd() *cobra.Command {
 Scan the QR code with your mobile device to open the script in the configured
 runtime (e.g. Pythonista 3 on iOS).
 
-Prerequisite:
+Prerequisites:
 	cloudflared must be installed and available on PATH.
-	qrrun uses Cloudflare Quick Tunnels (trycloudflare.com),
-	so account login is not required.
-	By default, qrrun generates a QR code for opening and running your
-	script in Pythonista3 via Cloudflare Quick Tunnels, unless you
-	explicitly override "--transport" or "--runtime".
+	qrrun uses Cloudflare Quick Tunnels (trycloudflare.com).
 
 Examples:
 	qrrun hello.py


### PR DESCRIPTION
## Summary
- align Prerequisites wording between README and CLI help
- use concise wording for cloudflared and quick tunnel requirements
- keep terminology consistent as Prerequisites

## Verification
- go test ./...
- go run ./cmd/qrrun --help