### PR TITLE
Add generic release playbook and README release section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# Agent Instructions for qrrun
+
+This file provides repository-level guidance for any coding agent (Copilot, Claude, Gemini, etc.) operating in this project.
+
+## Release Operations
+
+Use this playbook when asked to create a release (especially beta releases).
+
+### Goal
+
+Create a GitHub release by pushing a version tag that matches `v*`.
+This repository uses `.github/workflows/release.yml` for tag-triggered builds and release publishing.
+
+### Preconditions
+
+1. Work from `main`.
+2. Ensure local `main` is up to date with `origin/main`.
+3. Ensure working tree is clean.
+4. Ensure the target tag does not already exist locally or remotely.
+
+### Tag Rules
+
+- Stable example: `v0.2.0`
+- Beta example: `v0.2.0-beta.1`
+- Tag must start with `v` so the release workflow runs.
+
+### Standard Steps
+
+1. Sync main:
+
+```bash
+git switch main
+git pull --ff-only
+```
+
+2. Verify clean state:
+
+```bash
+git status --short --branch
+```
+
+3. Verify tag is unused:
+
+```bash
+git rev-parse -q --verify refs/tags/<TAG> || true
+git ls-remote --tags origin | grep "refs/tags/<TAG>$" || true
+```
+
+4. Create signed tag:
+
+```bash
+git tag -s <TAG> -m "<TAG>"
+```
+
+5. Push tag:
+
+```bash
+git push origin <TAG>
+```
+
+### Post-Release Verification
+
+1. Confirm workflow started:
+
+```bash
+gh run list --workflow release.yml --limit 5
+```
+
+2. Confirm release exists after workflow success:
+
+```bash
+gh release view <TAG>
+```
+
+3. If needed, open the workflow run URL and check failed job logs.
+
+### Failure Handling
+
+- If tag already exists, increment version suffix (for beta, increase `beta.N`).
+- If workflow does not trigger, verify tag name starts with `v` and was pushed to `origin`.
+- If release job is skipped, check `guard-main` job output in workflow logs.
+
+### Notes
+
+- Do not tag from feature branches.
+- Prefer signed tags for release traceability.
+- Keep release actions limited to requested scope (do not modify unrelated branches/tags).

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 BINARY := qrrun
 CMD     := ./cmd/qrrun
 GOLANGCI_LINT_VERSION := v1.64.8
-VERSION ?= v0.1.0-alpha.0
+VERSION ?= v0.0.0-dev
 COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE    := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -X 'main.version=$(VERSION)' -X 'main.commit=$(COMMIT)' -X 'main.date=$(DATE)'

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ gvm use go1.24.13
 ```
 
 The expected version is also stored in `.gvmrc`.
+
+## Release
+
+For release operations (including beta releases), see [AGENTS.md](AGENTS.md).

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	version = "v0.1.0-alpha.0"
+	version = "v0.0.0-dev"
 	commit  = "none"
 	date    = "unknown"
 )


### PR DESCRIPTION
## Summary
- add AGENTS.md with a generic release operation playbook for LLM agents
- add a Release section at the end of README
- link README release section to AGENTS.md

## Scope
- documentation only