### PR TITLE
Add Windows MSI installer packaging to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,11 +127,72 @@ jobs:
           path: dist/*.zip
           if-no-files-found: error
 
+  build-msi:
+    runs-on: windows-latest
+    needs: guard-main
+    if: needs.guard-main.outputs.on_main == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goarch: amd64
+            wix_arch: x64
+          - goarch: arm64
+            wix_arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install WiX Toolset
+        shell: powershell
+        run: |
+          choco install wixtoolset --version=3.14.1 -y
+          echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Build Windows binary and MSI
+        shell: powershell
+        env:
+          VERSION: ${{ needs.guard-main.outputs.version }}
+          GOARCH: ${{ matrix.goarch }}
+          WIX_ARCH: ${{ matrix.wix_arch }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+          $commit = "${env:GITHUB_SHA}".Substring(0,7)
+          $base = "qrrun_${env:VERSION}_windows_${env:GOARCH}"
+
+          New-Item -ItemType Directory -Path dist -Force | Out-Null
+
+          $env:CGO_ENABLED = "0"
+          $env:GOOS = "windows"
+          go build -trimpath -ldflags "-s -w -X 'main.version=${env:VERSION}' -X 'main.commit=${commit}' -X 'main.date=${date}'" -o "dist/${base}.exe" ./cmd/qrrun
+
+          $productVersion = [regex]::Match($env:VERSION, '^[vV]?(\d+\.\d+\.\d+)').Groups[1].Value
+          if ([string]::IsNullOrWhiteSpace($productVersion)) {
+            throw "Tag '$env:VERSION' must start with SemVer core (e.g. v1.2.3) for MSI versioning"
+          }
+
+          candle -nologo -arch $env:WIX_ARCH -dBinarySource="dist/${base}.exe" -dProductVersion=$productVersion -out "dist/${base}.wixobj" packaging/windows/qrrun.wxs
+          light -nologo -ext WixUIExtension -out "dist/${base}.msi" "dist/${base}.wixobj"
+
+      - name: Upload MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows-${{ matrix.goarch }}-msi
+          path: dist/*.msi
+          if-no-files-found: error
+
   release:
     runs-on: ubuntu-latest
     needs:
       - guard-main
       - build
+      - build-msi
     if: needs.guard-main.outputs.on_main == 'true'
     steps:
       - name: Download all packaged artifacts
@@ -149,3 +210,4 @@ jobs:
           files: |
             dist/*.tar.gz
             dist/*.zip
+            dist/*.msi

--- a/packaging/windows/qrrun.wxs
+++ b/packaging/windows/qrrun.wxs
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product
+    Id="*"
+    Name="qrrun"
+    Language="1033"
+    Version="$(var.ProductVersion)"
+    Manufacturer="qrrun maintainers"
+    UpgradeCode="B1A2C8E2-3E4B-4F93-ABF7-D39C45FB0C6D">
+    <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
+    <MajorUpgrade DowngradeErrorMessage="A newer version of qrrun is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
+    <Property Id="WixUISupportPerUser" Value="1" />
+    <Property Id="WixUISupportPerMachine" Value="1" />
+
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="WixPerMachineFolder">
+        <Directory Id="INSTALLDIR_MACHINE" Name="qrrun">
+          <Component Id="QrrunMachine" Guid="*" Condition="ALLUSERS=1">
+            <File Id="QrrunExeMachine" Source="$(var.BinarySource)" KeyPath="yes" Name="qrrun.exe" />
+            <Environment
+              Id="PathMachine"
+              Name="PATH"
+              Action="set"
+              Part="last"
+              Permanent="no"
+              System="yes"
+              Value="[INSTALLDIR_MACHINE]" />
+          </Component>
+        </Directory>
+      </Directory>
+      <Directory Id="WixPerUserFolder">
+        <Directory Id="INSTALLDIR_USER" Name="qrrun">
+          <Component Id="QrrunUser" Guid="*" Condition="ALLUSERS&lt;&gt;1">
+            <File Id="QrrunExeUser" Source="$(var.BinarySource)" KeyPath="yes" Name="qrrun.exe" />
+            <Environment
+              Id="PathUser"
+              Name="PATH"
+              Action="set"
+              Part="last"
+              Permanent="no"
+              System="no"
+              Value="[INSTALLDIR_USER]" />
+          </Component>
+        </Directory>
+      </Directory>
+    </Directory>
+
+    <Feature Id="MainFeature" Title="qrrun" Level="1">
+      <ComponentRef Id="QrrunMachine" />
+      <ComponentRef Id="QrrunUser" />
+    </Feature>
+
+    <UIRef Id="WixUI_Advanced" />
+    <UIRef Id="WixUI_ErrorProgressText" />
+  </Product>
+</Wix>


### PR DESCRIPTION
## Summary
- add a Windows MSI build job in release workflow (amd64/arm64)
- add WiX installer definition for per-user/per-machine install selection
- configure PATH updates for user/system scope and cleanup on uninstall
- attach generated MSI files to GitHub Releases

## Scope
- CI/CD packaging only