### PR TITLE
Add Homebrew formula generation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,55 @@ EOF
           path: dist
           merge-multiple: true
 
+      - name: Generate Homebrew formula
+        shell: bash
+        env:
+          VERSION: ${{ needs.guard-main.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          FORMULA_VERSION="${VERSION#v}"
+          DARWIN_AMD64="qrrun_${VERSION}_darwin_amd64.tar.gz"
+          DARWIN_ARM64="qrrun_${VERSION}_darwin_arm64.tar.gz"
+
+          SHA_AMD64="$(sha256sum "dist/${DARWIN_AMD64}" | awk '{print $1}')"
+          SHA_ARM64="$(sha256sum "dist/${DARWIN_ARM64}" | awk '{print $1}')"
+
+          mkdir -p dist/homebrew
+
+          cat > dist/homebrew/qrrun.rb <<EOF
+class Qrrun < Formula
+  desc "Tunnel local code and run it via QR"
+  homepage "https://github.com/${REPO}"
+  version "${FORMULA_VERSION}"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/${REPO}/releases/download/${VERSION}/${DARWIN_AMD64}"
+      sha256 "${SHA_AMD64}"
+    end
+
+    if Hardware::CPU.arm?
+      url "https://github.com/${REPO}/releases/download/${VERSION}/${DARWIN_ARM64}"
+      sha256 "${SHA_ARM64}"
+    end
+  end
+
+  def install
+    if Hardware::CPU.intel?
+      bin.install "qrrun_#{version}_darwin_amd64" => "qrrun"
+    else
+      bin.install "qrrun_#{version}_darwin_arm64" => "qrrun"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/qrrun --version")
+  end
+end
+EOF
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -243,3 +292,4 @@ EOF
             dist/*.zip
             dist/*.deb
             dist/*.rpm
+            dist/homebrew/*.rb


### PR DESCRIPTION
## Summary
- resolve release.yml conflict after pull
- generate Homebrew formula from release artifacts in release job
- attach generated formula file to GitHub Release assets
- keep existing tar.gz/zip/deb/rpm assets unchanged

## Scope
- CI/CD workflow only