### PR TITLE
Protect script delivery with bearer token auth

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,8 @@ package app
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -64,7 +66,12 @@ func Run(opts Options) error {
 		return err
 	}
 
-	srv, err := server.New(scriptBytes, "text/x-python; charset=utf-8", os.Stdout)
+	bearerToken, err := generateBearerToken()
+	if err != nil {
+		return fmt.Errorf("generate bearer token: %w", err)
+	}
+
+	srv, err := server.New(scriptBytes, "text/x-python; charset=utf-8", bearerToken, os.Stdout)
 	if err != nil {
 		return err
 	}
@@ -99,7 +106,7 @@ func Run(opts Options) error {
 
 	// Build the QR code URL: replace the local base URL with the public one,
 	// then let the runtime wrap it in the appropriate URL scheme.
-	scriptPublicURL := rt.QRCodeURL(replaceBase(srv.ScriptURL(), publicURL))
+	scriptPublicURL := rt.QRCodeURL(replaceBase(srv.ScriptURL(), publicURL), bearerToken)
 
 	fmt.Fprintf(opts.Output, "\nScan the QR code below with your phone:\n\n")
 	qrterminal.GenerateWithConfig(scriptPublicURL, qrterminal.Config{
@@ -184,6 +191,14 @@ func Run(opts Options) error {
 		}
 	}
 	return nil
+}
+
+func generateBearerToken() (string, error) {
+	raw := make([]byte, 24)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
 }
 
 func loadScriptContent(scriptPath string, input io.Reader) ([]byte, error) {

--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -11,7 +11,7 @@ type Pythonista struct {
 }
 
 // QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
-func (p *Pythonista) QRCodeURL(publicURL string) string {
-	code := fmt.Sprintf("import requests as r;exec(r.get(%q).text)", publicURL)
+func (p *Pythonista) QRCodeURL(publicURL string, bearerToken string) string {
+	code := fmt.Sprintf("import requests as r;exec(r.get(%q,headers={'Authorization':'Bearer %s'}).text)", publicURL, bearerToken)
 	return fmt.Sprintf("%s://?exec=%s", p.Scheme, code)
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -13,7 +13,7 @@ import (
 type Runtime interface {
 	// QRCodeURL returns the URL to encode in the QR code given the public URL
 	// of the script.
-	QRCodeURL(publicURL string) string
+	QRCodeURL(publicURL string, bearerToken string) string
 }
 
 // New returns a Runtime for the given name or an error when the name is

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -38,6 +38,7 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 	}
 
 	rawURL := "https://example.trycloudflare.com/hello.py"
+	bearerToken := "test-token-123"
 
 	for _, tc := range tests {
 		rt, err := runtime.New(tc.name)
@@ -45,7 +46,7 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 			t.Fatalf("unexpected error for %q: %v", tc.name, err)
 		}
 
-		got := rt.QRCodeURL(rawURL)
+		got := rt.QRCodeURL(rawURL, bearerToken)
 		if !strings.HasPrefix(got, tc.scheme+"://") {
 			t.Errorf("expected %s:// scheme, got %q", tc.scheme, got)
 		}
@@ -64,6 +65,12 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		}
 		if !strings.Contains(execCode, "exec(r.get(") {
 			t.Errorf("expected r.get execution in exec code for %q, got %q", tc.name, execCode)
+		}
+		if !strings.Contains(execCode, "Authorization") {
+			t.Errorf("expected Authorization header in exec code for %q, got %q", tc.name, execCode)
+		}
+		if !strings.Contains(execCode, "Bearer "+bearerToken) {
+			t.Errorf("expected Bearer token in exec code for %q, got %q", tc.name, execCode)
 		}
 		if !strings.Contains(execCode, rawURL) {
 			t.Errorf("expected raw URL in exec code for %q, got %q", tc.name, execCode)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,12 +12,14 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 )
 
 // Server is an in-memory single-script HTTP server.
 type Server struct {
 	scriptID    string
+	bearerToken string
 	scriptBytes []byte
 	contentType string
 	requestLog  io.Writer
@@ -32,10 +34,13 @@ type Server struct {
 
 // New creates a Server that serves scriptBytes on a random free port.
 // The script is exposed at /<uuid-without-extension>.
-func New(scriptBytes []byte, contentType string, requestLog io.Writer) (*Server, error) {
+func New(scriptBytes []byte, contentType string, bearerToken string, requestLog io.Writer) (*Server, error) {
 	ln, baseURL, originURL, cleanup, err := newOriginListener()
 	if err != nil {
 		return nil, err
+	}
+	if strings.TrimSpace(bearerToken) == "" {
+		return nil, fmt.Errorf("server: bearer token is required")
 	}
 	if requestLog == nil {
 		requestLog = os.Stdout
@@ -48,6 +53,7 @@ func New(scriptBytes []byte, contentType string, requestLog io.Writer) (*Server,
 
 	return &Server{
 		scriptID:    scriptID,
+		bearerToken: bearerToken,
 		scriptBytes: scriptBytes,
 		contentType: contentType,
 		requestLog:  requestLog,
@@ -93,6 +99,12 @@ func (s *Server) Serve(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/"+s.scriptID, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(s.requestLog, "request: method=%s path=%s remote=%s\n", r.Method, r.URL.Path, r.RemoteAddr)
+		auth := strings.TrimSpace(r.Header.Get("Authorization"))
+		if auth != "Bearer "+s.bearerToken {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -16,9 +16,11 @@ import (
 	"github.com/sakurai-youhei/qrrun/internal/server"
 )
 
+const testBearerToken = "test-bearer-token"
+
 func TestServer_ServesScriptFile(t *testing.T) {
 	content := "print('hello')\n"
-	srv, err := server.New([]byte(content), "text/x-python; charset=utf-8", io.Discard)
+	srv, err := server.New([]byte(content), "text/x-python; charset=utf-8", testBearerToken, io.Discard)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -36,7 +38,7 @@ func TestServer_ServesScriptFile(t *testing.T) {
 	// Give the server a moment to start.
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := serverHTTPClient(srv.OriginURL()).Get(srv.ScriptURL())
+	resp, err := doRequest(serverHTTPClient(srv.OriginURL()), http.MethodGet, srv.ScriptURL(), testBearerToken, nil)
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
@@ -59,7 +61,7 @@ func TestServer_ServesScriptFile(t *testing.T) {
 }
 
 func TestServer_URLFormat(t *testing.T) {
-	srv, err := server.New([]byte(""), "text/x-python; charset=utf-8", io.Discard)
+	srv, err := server.New([]byte(""), "text/x-python; charset=utf-8", testBearerToken, io.Discard)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -95,7 +97,7 @@ func TestServer_URLFormat(t *testing.T) {
 }
 
 func TestServer_FirstRequestServed_IsSignaled(t *testing.T) {
-	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", io.Discard)
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", testBearerToken, io.Discard)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -115,7 +117,7 @@ func TestServer_FirstRequestServed_IsSignaled(t *testing.T) {
 	default:
 	}
 
-	resp, err := serverHTTPClient(srv.OriginURL()).Get(srv.ScriptURL())
+	resp, err := doRequest(serverHTTPClient(srv.OriginURL()), http.MethodGet, srv.ScriptURL(), testBearerToken, nil)
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
@@ -129,7 +131,7 @@ func TestServer_FirstRequestServed_IsSignaled(t *testing.T) {
 }
 
 func TestServer_FirstRequestServed_HeadDoesNotSignal(t *testing.T) {
-	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", io.Discard)
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", testBearerToken, io.Discard)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -147,6 +149,7 @@ func TestServer_FirstRequestServed_HeadDoesNotSignal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create HEAD request: %v", err)
 	}
+	req.Header.Set("Authorization", "Bearer "+testBearerToken)
 	resp, err := serverHTTPClient(srv.OriginURL()).Do(req)
 	if err != nil {
 		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
@@ -162,7 +165,7 @@ func TestServer_FirstRequestServed_HeadDoesNotSignal(t *testing.T) {
 
 func TestServer_LogsAllRequests(t *testing.T) {
 	var logs bytes.Buffer
-	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", &logs)
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", testBearerToken, &logs)
 	if err != nil {
 		t.Fatalf("server.New: %v", err)
 	}
@@ -176,7 +179,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	if _, err := serverHTTPClient(srv.OriginURL()).Get(srv.ScriptURL()); err != nil {
+	if _, err := doRequest(serverHTTPClient(srv.OriginURL()), http.MethodGet, srv.ScriptURL(), testBearerToken, nil); err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
 
@@ -184,6 +187,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create HEAD request: %v", err)
 	}
+	req.Header.Set("Authorization", "Bearer "+testBearerToken)
 	resp, err := serverHTTPClient(srv.OriginURL()).Do(req)
 	if err != nil {
 		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
@@ -194,6 +198,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create POST request: %v", err)
 	}
+	req.Header.Set("Authorization", "Bearer "+testBearerToken)
 	resp, err = serverHTTPClient(srv.OriginURL()).Do(req)
 	if err != nil {
 		t.Fatalf("POST %s: %v", srv.ScriptURL(), err)
@@ -210,6 +215,47 @@ func TestServer_LogsAllRequests(t *testing.T) {
 	if !strings.Contains(got, "method=POST") {
 		t.Fatalf("expected POST log, got: %q", got)
 	}
+}
+
+func TestServer_RejectsUnauthorizedRequest(t *testing.T) {
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", testBearerToken, io.Discard)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := doRequest(serverHTTPClient(srv.OriginURL()), http.MethodGet, srv.ScriptURL(), "wrong-token", nil)
+	if err != nil {
+		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 Unauthorized, got %d", resp.StatusCode)
+	}
+
+	select {
+	case <-srv.FirstRequestServed():
+		t.Fatal("first request signal should not be closed for unauthorized request")
+	default:
+	}
+}
+
+func doRequest(client *http.Client, method, url, bearerToken string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	return client.Do(req)
 }
 
 func serverHTTPClient(originURL string) *http.Client {


### PR DESCRIPTION
## Summary
- generate a random bearer token per run
- require Authorization: Bearer <token> on script delivery endpoint
- embed bearer token in Pythonista QR exec code requests headers
- return 401 for unauthorized requests and keep delivery signaling for authorized requests only
- update runtime/server tests for the new auth behavior

## Scope
- app, runtime, and server behavior changes
- tests included