### PR TITLE
Stabilize cloudflared probe and tunnel readiness behavior

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -106,7 +107,11 @@ func Run(opts Options) error {
 
 	// Build the QR code URL: replace the local base URL with the public one,
 	// then let the runtime wrap it in the appropriate URL scheme.
-	scriptPublicURL := rt.QRCodeURL(replaceBase(srv.ScriptURL(), publicURL), bearerToken)
+	rawScriptPublicURL := replaceBase(srv.ScriptURL(), publicURL)
+	if err := waitForPublicOriginReady(ctx, rawScriptPublicURL, bearerToken, 5*time.Second); err != nil {
+		return fmt.Errorf("tunnel not ready: %w", err)
+	}
+	scriptPublicURL := rt.QRCodeURL(rawScriptPublicURL, bearerToken)
 
 	fmt.Fprintf(opts.Output, "\nScan the QR code below with your phone:\n\n")
 	qrterminal.GenerateWithConfig(scriptPublicURL, qrterminal.Config{
@@ -199,6 +204,49 @@ func generateBearerToken() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(raw), nil
+}
+
+func waitForPublicOriginReady(ctx context.Context, rawScriptPublicURL, bearerToken string, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	deadlineCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	client := &http.Client{Timeout: 1500 * time.Millisecond}
+	ticker := time.NewTicker(150 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastErr error
+
+	for {
+		req, err := http.NewRequestWithContext(deadlineCtx, http.MethodHead, rawScriptPublicURL, nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				return nil
+			}
+			lastErr = fmt.Errorf("unexpected status: %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-deadlineCtx.Done():
+			if lastErr != nil {
+				return lastErr
+			}
+			return deadlineCtx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func loadScriptContent(scriptPath string, input io.Reader) ([]byte, error) {

--- a/internal/app/readiness_test.go
+++ b/internal/app/readiness_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWaitForPublicOriginReady_SucceedsAfterTransient502(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if atomic.AddInt32(&calls, 1) < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	if err := waitForPublicOriginReady(context.Background(), ts.URL, "token", 3*time.Second); err != nil {
+		t.Fatalf("waitForPublicOriginReady: %v", err)
+	}
+}
+
+func TestWaitForPublicOriginReady_FailsForPersistentBadStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	err := waitForPublicOriginReady(context.Background(), ts.URL, "token", 400*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,155 +3,172 @@
 package server
 
 import (
-	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"errors"
-	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"os"
-	"strings"
-	"sync"
+"context"
+"crypto/rand"
+"encoding/hex"
+"errors"
+"fmt"
+"io"
+"net"
+"net/http"
+"os"
+"strings"
+"sync"
 )
 
 // Server is an in-memory single-script HTTP server.
 type Server struct {
-	scriptID    string
-	bearerToken string
-	scriptBytes []byte
-	contentType string
-	requestLog  io.Writer
-	listener    net.Listener
-	baseURL     string
-	originURL   string
-	cleanup     func()
-	firstReqCh  chan struct{}
-	deliveryCh  chan struct{}
-	firstReq    sync.Once
+scriptID    string
+bearerToken string
+scriptBytes []byte
+contentType string
+requestLog  io.Writer
+listener    net.Listener
+baseURL     string
+originURL   string
+cleanup     func()
+firstReqCh  chan struct{}
+deliveryCh  chan struct{}
+firstReq    sync.Once
 }
 
 // New creates a Server that serves scriptBytes on a random free port.
 // The script is exposed at /<uuid-without-extension>.
 func New(scriptBytes []byte, contentType string, bearerToken string, requestLog io.Writer) (*Server, error) {
-	ln, baseURL, originURL, cleanup, err := newOriginListener()
-	if err != nil {
-		return nil, err
-	}
-	if strings.TrimSpace(bearerToken) == "" {
-		return nil, fmt.Errorf("server: bearer token is required")
-	}
-	if requestLog == nil {
-		requestLog = os.Stdout
-	}
+ln, baseURL, originURL, cleanup, err := newOriginListener()
+if err != nil {
+return nil, err
+}
+if strings.TrimSpace(bearerToken) == "" {
+return nil, fmt.Errorf("server: bearer token is required")
+}
+if requestLog == nil {
+requestLog = os.Stdout
+}
 
-	scriptID, err := newScriptID()
-	if err != nil {
-		return nil, fmt.Errorf("server: script id: %w", err)
-	}
+scriptID, err := newScriptID()
+if err != nil {
+return nil, fmt.Errorf("server: script id: %w", err)
+}
 
-	return &Server{
-		scriptID:    scriptID,
-		bearerToken: bearerToken,
-		scriptBytes: scriptBytes,
-		contentType: contentType,
-		requestLog:  requestLog,
-		listener:    ln,
-		baseURL:     baseURL,
-		originURL:   originURL,
-		cleanup:     cleanup,
-		firstReqCh:  make(chan struct{}),
-		deliveryCh:  make(chan struct{}, 32),
-	}, nil
+return &Server{
+scriptID:    scriptID,
+bearerToken: bearerToken,
+scriptBytes: scriptBytes,
+contentType: contentType,
+requestLog:  requestLog,
+listener:    ln,
+baseURL:     baseURL,
+originURL:   originURL,
+cleanup:     cleanup,
+firstReqCh:  make(chan struct{}),
+deliveryCh:  make(chan struct{}, 32),
+}, nil
 }
 
 // URL returns the local HTTP base URL used for script URL composition.
 func (s *Server) URL() string {
-	return s.baseURL
+return s.baseURL
 }
 
 // OriginURL returns the local origin URL for cloudflared.
 func (s *Server) OriginURL() string {
-	return s.originURL
+return s.originURL
 }
 
 // ScriptURL returns the full URL for the served script file.
 func (s *Server) ScriptURL() string {
-	return s.URL() + "/" + s.scriptID
+return s.URL() + "/" + s.scriptID
 }
 
 // FirstRequestServed is closed once the script endpoint is served for the first time.
 func (s *Server) FirstRequestServed() <-chan struct{} {
-	return s.firstReqCh
+return s.firstReqCh
 }
 
 // DeliveryEvents receives an event each time script content is successfully written.
 func (s *Server) DeliveryEvents() <-chan struct{} {
-	return s.deliveryCh
+return s.deliveryCh
 }
 
 // Serve starts the HTTP server and blocks until ctx is cancelled or an
 // unrecoverable error occurs.
 func (s *Server) Serve(ctx context.Context) error {
-	defer s.cleanup()
+defer s.cleanup()
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/"+s.scriptID, func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(s.requestLog, "request: method=%s path=%s remote=%s\n", r.Method, r.URL.Path, r.RemoteAddr)
-		auth := strings.TrimSpace(r.Header.Get("Authorization"))
-		if auth != "Bearer "+s.bearerToken {
-			w.Header().Set("WWW-Authenticate", "Bearer")
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		if r.Method != http.MethodGet && r.Method != http.MethodHead {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
-		w.Header().Set("Content-Type", s.contentType)
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("Cache-Control", "no-store")
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(s.scriptBytes)))
-		if r.Method == http.MethodHead {
-			return
-		}
-		if _, err := w.Write(s.scriptBytes); err == nil {
-			s.firstReq.Do(func() {
-				close(s.firstReqCh)
-			})
-			select {
-			case s.deliveryCh <- struct{}{}:
-			default:
-			}
-		}
-	})
-
-	srv := &http.Server{Handler: mux}
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- srv.Serve(s.listener)
-	}()
-
-	select {
-	case <-ctx.Done():
-		if shutdownErr := srv.Shutdown(context.Background()); shutdownErr != nil {
-			return fmt.Errorf("server: shutdown: %w", shutdownErr)
-		}
-		return nil
-	case err := <-errCh:
-		if errors.Is(err, http.ErrServerClosed) {
-			return nil
-		}
-		return fmt.Errorf("server: serve: %w", err)
-	}
+mux := http.NewServeMux()
+mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+if r.Method != http.MethodGet && r.Method != http.MethodHead {
+w.WriteHeader(http.StatusMethodNotAllowed)
+return
 }
+w.Header().Set("Cache-Control", "no-store")
+if r.Method == http.MethodHead {
+w.WriteHeader(http.StatusOK)
+return
+}
+w.WriteHeader(http.StatusOK)
+_, _ = io.WriteString(w, "ok")
+})
+mux.HandleFunc("/"+s.scriptID, func(w http.ResponseWriter, r *http.Request) {
+fmt.Fprintf(s.requestLog, "request: method=%s path=%s remote=%s\n", r.Method, r.URL.Path, r.RemoteAddr)
+if r.Method != http.MethodGet && r.Method != http.MethodHead {
+w.WriteHeader(http.StatusMethodNotAllowed)
+return
+}
+// Allow unauthenticated HEAD probes so cloudflared can verify origin reachability.
+if r.Method != http.MethodHead {
+auth := strings.TrimSpace(r.Header.Get("Authorization"))
+if auth != "Bearer "+s.bearerToken {
+w.Header().Set("WWW-Authenticate", "Bearer")
+w.WriteHeader(http.StatusUnauthorized)
+return
+}
+}
+w.Header().Set("Content-Type", s.contentType)
+w.Header().Set("X-Content-Type-Options", "nosniff")
+w.Header().Set("Cache-Control", "no-store")
+w.Header().Set("Content-Length", fmt.Sprintf("%d", len(s.scriptBytes)))
+if r.Method == http.MethodHead {
+return
+}
+if _, err := w.Write(s.scriptBytes); err == nil {
+s.firstReq.Do(func() {
+close(s.firstReqCh)
+})
+select {
+case s.deliveryCh <- struct{}{}:
+default:
+}
+}
+})
+
+srv := &http.Server{Handler: mux}
+
+errCh := make(chan error, 1)
+go func() {
+errCh <- srv.Serve(s.listener)
+}()
+
+select {
+case <-ctx.Done():
+if shutdownErr := srv.Shutdown(context.Background()); shutdownErr != nil {
+return fmt.Errorf("server: shutdown: %w", shutdownErr)
+}
+return nil
+case err := <-errCh:
+if errors.Is(err, http.ErrServerClosed) {
+return nil
+}
+return fmt.Errorf("server: serve: %w", err)
+}
+}
+
 func newScriptID() (string, error) {
-	raw := make([]byte, 16)
-	if _, err := rand.Read(raw); err != nil {
-		return "", err
-	}
-	// 32 hex chars, extensionless UUID-like identifier suitable for URL path.
-	return hex.EncodeToString(raw), nil
+raw := make([]byte, 16)
+if _, err := rand.Read(raw); err != nil {
+return "", err
+}
+// 32 hex chars, extensionless UUID-like identifier suitable for URL path.
+return hex.EncodeToString(raw), nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -149,10 +149,12 @@ func TestServer_FirstRequestServed_HeadDoesNotSignal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create HEAD request: %v", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+testBearerToken)
 	resp, err := serverHTTPClient(srv.OriginURL()).Do(req)
 	if err != nil {
 		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 OK for HEAD probe, got %d", resp.StatusCode)
 	}
 	_ = resp.Body.Close()
 
@@ -246,6 +248,37 @@ func TestServer_RejectsUnauthorizedRequest(t *testing.T) {
 	case <-srv.FirstRequestServed():
 		t.Fatal("first request signal should not be closed for unauthorized request")
 	default:
+	}
+}
+
+func TestServer_HealthEndpoint_AllowsNoAuth(t *testing.T) {
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", testBearerToken, io.Discard)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	req, err := http.NewRequest(http.MethodHead, srv.URL()+"/", nil)
+	if err != nil {
+		t.Fatalf("create HEAD health request: %v", err)
+	}
+
+	resp, err := serverHTTPClient(srv.OriginURL()).Do(req)
+	if err != nil {
+		t.Fatalf("HEAD %s: %v", srv.URL()+"/", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected health endpoint 200, got %d", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep tunnel readiness check fail-fast (`tunnel not ready`) behavior
- adjust local origin server behavior for cloudflared probe compatibility
- add/adjust server and app readiness tests

## Scope
- internal/app and internal/server changes
- tests included