### PR TITLE
Use __import__("requests") single-expression payload

### DIFF
--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -12,6 +12,6 @@ type Pythonista struct {
 
 // QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
 func (p *Pythonista) QRCodeURL(publicURL string, bearerToken string) string {
-	code := fmt.Sprintf("import requests as r;exec(r.get(%q,headers={'Authorization':'Bearer %s'}).text)", publicURL, bearerToken)
+	code := fmt.Sprintf("exec(__import__(\"requests\").get(%q,headers={\"Authorization\":\"Bearer %s\"}).text)", publicURL, bearerToken)
 	return fmt.Sprintf("%s://?exec=%s", p.Scheme, code)
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -60,11 +60,11 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		if execCode == "" {
 			t.Errorf("expected exec query parameter for %q, got %q", tc.name, got)
 		}
-		if !strings.HasPrefix(execCode, "import requests as r;") {
-			t.Errorf("expected requests one-liner prefix in exec code for %q, got %q", tc.name, execCode)
+		if !strings.HasPrefix(execCode, "exec(__import__(\"requests\").get(") {
+			t.Errorf("expected single-expression __import__ prefix in exec code for %q, got %q", tc.name, execCode)
 		}
-		if !strings.Contains(execCode, "exec(r.get(") {
-			t.Errorf("expected r.get execution in exec code for %q, got %q", tc.name, execCode)
+		if !strings.Contains(execCode, ").text)") {
+			t.Errorf("expected .text execution suffix in exec code for %q, got %q", tc.name, execCode)
 		}
 		if !strings.Contains(execCode, "Authorization") {
 			t.Errorf("expected Authorization header in exec code for %q, got %q", tc.name, execCode)


### PR DESCRIPTION
## Summary
- change Pythonista QR exec payload to a single expression
- use `__import__("requests")` as the entrypoint
- keep bearer Authorization header behavior intact
- update runtime tests to match the new payload format

## Scope
- runtime payload formatting and tests only