### PR TITLE
Add --cloudflared-opts passthrough for cloudflared tunnel

### DIFF
--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -10,6 +10,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ func newRootCmd() *cobra.Command {
 	var keepServing bool
 	var exitQuietPeriod time.Duration
 	var urlOnly bool
+	var cloudflaredOpts string
 
 	cmd := &cobra.Command{
 		Use:   "qrrun [flags] <script|-]",
@@ -62,6 +64,7 @@ Examples:
 				KeepServing:     keepServingMode,
 				ExitQuietPeriod: exitQuietPeriod,
 				URLOnly:         urlOnly,
+				CloudflaredOpts: strings.Fields(cloudflaredOpts),
 			})
 		},
 		SilenceUsage: true,
@@ -80,6 +83,8 @@ Examples:
 		`Quiet period before exit in default mode (examples: 300ms, 1s). Ignored when --keep-serving is enabled.`)
 	cmd.Flags().BoolVar(&urlOnly, "url-only", false,
 		`Print only the runtime URL as a single line (no QR code or status text).`)
+	cmd.Flags().StringVar(&cloudflaredOpts, "cloudflared-opts", "",
+		`Extra options passed to "cloudflared tunnel" (example: --cloudflared-opts='--loglevel debug').`)
 
 	return cmd
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -28,6 +28,7 @@ type Options struct {
 	KeepServing     bool
 	ExitQuietPeriod time.Duration
 	URLOnly         bool
+	CloudflaredOpts []string
 	Input           io.Reader // source for script content when ScriptPath is "-"; defaults to os.Stdin
 	Output          io.Writer // destination for the QR code; defaults to os.Stdout
 }
@@ -60,6 +61,9 @@ func Run(opts Options) error {
 		if cf, ok := t.(*transport.Cloudflared); ok {
 			cf.CommandLog = io.Discard
 		}
+	}
+	if cf, ok := t.(*transport.Cloudflared); ok {
+		cf.ExtraArgs = append([]string(nil), opts.CloudflaredOpts...)
 	}
 
 	rt, err := runtime.New(opts.RuntimeName)

--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -17,6 +17,7 @@ import (
 // The cloudflared binary must be available on PATH.
 type Cloudflared struct {
 	CommandLog io.Writer
+	ExtraArgs  []string
 }
 
 // tunnelURLRe matches the public URL printed by cloudflared logs.
@@ -26,15 +27,8 @@ var tunnelURLRe = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 // resulting public URL to urlCh.  It returns when ctx is cancelled or the
 // subprocess exits unexpectedly.
 func (c *Cloudflared) Expose(ctx context.Context, localURL string, urlCh chan<- string) error {
-	args := []string{"tunnel", "--loglevel", "debug"}
-	if strings.HasPrefix(localURL, "unix://") {
-		socketPath := strings.TrimPrefix(localURL, "unix://")
-		args = append(args, "--url", "http://localhost", "--unix-socket", socketPath)
-		fmt.Fprintf(c.commandLogWriter(), "transport command: cloudflared tunnel --loglevel debug --url http://localhost --unix-socket %s\n", socketPath)
-	} else {
-		args = append(args, "--url", localURL)
-		fmt.Fprintf(c.commandLogWriter(), "transport command: cloudflared tunnel --loglevel debug --url %s\n", localURL)
-	}
+	args := c.buildArgs(localURL)
+	fmt.Fprintf(c.commandLogWriter(), "transport command: cloudflared %s\n", strings.Join(args, " "))
 
 	cmd := exec.CommandContext(ctx, "cloudflared", args...)
 
@@ -148,6 +142,20 @@ waitURL:
 		return fmt.Errorf("cloudflared: quick tunnel URL not found in output\ncloudflared output:\n%s", strings.TrimSpace(outputCapture.String()))
 	}
 	return nil
+}
+
+func (c *Cloudflared) buildArgs(localURL string) []string {
+	args := []string{"tunnel"}
+	if len(c.ExtraArgs) > 0 {
+		args = append(args, c.ExtraArgs...)
+	}
+	if strings.HasPrefix(localURL, "unix://") {
+		socketPath := strings.TrimPrefix(localURL, "unix://")
+		args = append(args, "--url", "http://localhost", "--unix-socket", socketPath)
+		return args
+	}
+	args = append(args, "--url", localURL)
+	return args
 }
 
 func (c *Cloudflared) commandLogWriter() io.Writer {

--- a/internal/transport/cloudflared_test.go
+++ b/internal/transport/cloudflared_test.go
@@ -1,6 +1,9 @@
 package transport
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestTunnelURLRe_Match(t *testing.T) {
 	line := "INF +--------------------------------------------------------------------------------------------+ https://fancy-moon-1234.trycloudflare.com"
@@ -21,5 +24,23 @@ func TestTunnelURLRe_NoMatch(t *testing.T) {
 		if got := tunnelURLRe.FindString(line); got != "" {
 			t.Fatalf("expected no match for %q, got %q", line, got)
 		}
+	}
+}
+
+func TestCloudflaredBuildArgs_WithExtraOptions(t *testing.T) {
+	c := &Cloudflared{ExtraArgs: []string{"--loglevel", "debug"}}
+	got := c.buildArgs("http://127.0.0.1:12345")
+	want := []string{"tunnel", "--loglevel", "debug", "--url", "http://127.0.0.1:12345"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
+	}
+}
+
+func TestCloudflaredBuildArgs_UnixSocketOrigin(t *testing.T) {
+	c := &Cloudflared{ExtraArgs: []string{"--loglevel", "debug"}}
+	got := c.buildArgs("unix:///tmp/qrrun.sock")
+	want := []string{"tunnel", "--loglevel", "debug", "--url", "http://localhost", "--unix-socket", "/tmp/qrrun.sock"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- add `--cloudflared-opts` CLI option
- pass parsed options from CLI -> app options -> cloudflared transport
- append extra options to `cloudflared tunnel` arguments
- keep output capture/logging behavior and add argument-building tests

## Scope
- cmd/qrrun/main.go
- internal/app/app.go
- internal/transport/cloudflared.go
- internal/transport/cloudflared_test.go

## Notes
- no README changes