### PR TITLE
Fix cloudflared origin for unix socket listener

### DIFF
--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -26,15 +26,8 @@ var tunnelURLRe = regexp.MustCompile(`https://[a-z0-9-]+\.trycloudflare\.com`)
 // resulting public URL to urlCh.  It returns when ctx is cancelled or the
 // subprocess exits unexpectedly.
 func (c *Cloudflared) Expose(ctx context.Context, localURL string, urlCh chan<- string) error {
-	args := []string{"tunnel", "--loglevel", "debug"}
-	if strings.HasPrefix(localURL, "unix://") {
-		socketPath := strings.TrimPrefix(localURL, "unix://")
-		args = append(args, "--url", "http://localhost", "--unix-socket", socketPath)
-		fmt.Fprintf(c.commandLogWriter(), "transport command: cloudflared tunnel --loglevel debug --url http://localhost --unix-socket %s\n", socketPath)
-	} else {
-		args = append(args, "--url", localURL)
-		fmt.Fprintf(c.commandLogWriter(), "transport command: cloudflared tunnel --loglevel debug --url %s\n", localURL)
-	}
+	args := c.buildArgs(localURL)
+	fmt.Fprintf(c.commandLogWriter(), "transport command: cloudflared %s\n", strings.Join(args, " "))
 
 	cmd := exec.CommandContext(ctx, "cloudflared", args...)
 
@@ -148,6 +141,16 @@ waitURL:
 		return fmt.Errorf("cloudflared: quick tunnel URL not found in output\ncloudflared output:\n%s", strings.TrimSpace(outputCapture.String()))
 	}
 	return nil
+}
+
+func (c *Cloudflared) buildArgs(localURL string) []string {
+	args := []string{"tunnel", "--loglevel", "debug"}
+	if strings.HasPrefix(localURL, "unix://") {
+		socketPath := strings.TrimPrefix(localURL, "unix://")
+		// Use unix socket URL directly so cloudflared does not fall back to localhost:80.
+		return append(args, "--url", "unix:"+socketPath)
+	}
+	return append(args, "--url", localURL)
 }
 
 func (c *Cloudflared) commandLogWriter() io.Writer {

--- a/internal/transport/cloudflared_test.go
+++ b/internal/transport/cloudflared_test.go
@@ -1,6 +1,9 @@
 package transport
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestTunnelURLRe_Match(t *testing.T) {
 	line := "INF +--------------------------------------------------------------------------------------------+ https://fancy-moon-1234.trycloudflare.com"
@@ -21,5 +24,23 @@ func TestTunnelURLRe_NoMatch(t *testing.T) {
 		if got := tunnelURLRe.FindString(line); got != "" {
 			t.Fatalf("expected no match for %q, got %q", line, got)
 		}
+	}
+}
+
+func TestCloudflaredBuildArgs_TCPOrigin(t *testing.T) {
+	c := &Cloudflared{}
+	got := c.buildArgs("http://127.0.0.1:8080")
+	want := []string{"tunnel", "--loglevel", "debug", "--url", "http://127.0.0.1:8080"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
+	}
+}
+
+func TestCloudflaredBuildArgs_UnixOrigin(t *testing.T) {
+	c := &Cloudflared{}
+	got := c.buildArgs("unix:///tmp/qrrun.sock")
+	want := []string{"tunnel", "--loglevel", "debug", "--url", "unix:/tmp/qrrun.sock"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- fix unix-origin cloudflared args to avoid fallback dial to localhost:80
- use --url unix:/path/to.sock for unix listeners instead of --url http://localhost with --unix-socket
- keep tcp origin behavior unchanged
- add tests for unix and tcp argument construction

## Scope
- internal/transport/cloudflared.go
- internal/transport/cloudflared_test.go