### PR TITLE
Fix cloudflared unix URL format handling

### DIFF
--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -150,9 +150,8 @@ func (c *Cloudflared) buildArgs(localURL string) []string {
 		args = append(args, c.ExtraArgs...)
 	}
 	if strings.HasPrefix(localURL, "unix://") {
-		socketPath := strings.TrimPrefix(localURL, "unix://")
-		// Use unix socket URL directly so cloudflared does not fall back to localhost:80.
-		return append(args, "--url", "unix:"+socketPath)
+		// Keep unix URL as-is (unix:///path) to avoid it being interpreted as http://unix:/path.
+		return append(args, "--url", localURL)
 	}
 	return append(args, "--url", localURL)
 }

--- a/internal/transport/cloudflared_test.go
+++ b/internal/transport/cloudflared_test.go
@@ -39,7 +39,7 @@ func TestCloudflaredBuildArgs_WithExtraOptions(t *testing.T) {
 func TestCloudflaredBuildArgs_UnixOrigin(t *testing.T) {
 	c := &Cloudflared{ExtraArgs: []string{"--loglevel", "debug"}}
 	got := c.buildArgs("unix:///tmp/qrrun.sock")
-	want := []string{"tunnel", "--loglevel", "debug", "--url", "unix:/tmp/qrrun.sock"}
+	want := []string{"tunnel", "--loglevel", "debug", "--url", "unix:///tmp/qrrun.sock"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
 	}


### PR DESCRIPTION
## Summary
- pass unix origin URL through unchanged when building cloudflared args
- avoid malformed origin like http://unix:/... that triggers DNS lookup for host 'unix'
- update transport tests to assert unix:///... is preserved

## Scope
- internal/transport/cloudflared.go
- internal/transport/cloudflared_test.go