### PR TITLE
Add transport stdout/stderr output controls

### DIFF
--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -36,6 +36,8 @@ func newRootCmd() *cobra.Command {
 	var runtimeName string
 	var keepServing bool
 	var exitQuietPeriod time.Duration
+	var transportStderr bool
+	var transportStdout bool
 	var urlOnly bool
 	var transportOpts string
 
@@ -63,6 +65,8 @@ Examples:
 				ScriptPath:      args[0],
 				KeepServing:     keepServingMode,
 				ExitQuietPeriod: exitQuietPeriod,
+				TransportStdout: transportStdout,
+				TransportStderr: transportStderr,
 				URLOnly:         urlOnly,
 				CloudflaredOpts: strings.Fields(transportOpts),
 			})
@@ -83,6 +87,10 @@ Examples:
 		`Tunnel transport to use. Available: cloudflared`)
 	cmd.Flags().StringVar(&transportOpts, "transport-opts", "",
 		`Extra options passed to the selected transport command (example: --transport-opts='--loglevel debug').`)
+	cmd.Flags().BoolVar(&transportStderr, "transport-stderr", true,
+		`Print transport stderr output to console.`)
+	cmd.Flags().BoolVar(&transportStdout, "transport-stdout", true,
+		`Print transport stdout output to console.`)
 	cmd.Flags().BoolVar(&urlOnly, "url-only", false,
 		`Print only the runtime URL as a single line (no QR code or status text).`)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,6 +27,8 @@ type Options struct {
 	ScriptPath      string
 	KeepServing     bool
 	ExitQuietPeriod time.Duration
+	TransportStdout bool
+	TransportStderr bool
 	URLOnly         bool
 	CloudflaredOpts []string
 	Input           io.Reader // source for script content when ScriptPath is "-"; defaults to os.Stdin
@@ -64,6 +66,13 @@ func Run(opts Options) error {
 	}
 	if cf, ok := t.(*transport.Cloudflared); ok {
 		cf.ExtraArgs = append([]string(nil), opts.CloudflaredOpts...)
+		cf.LogStdout = opts.TransportStdout
+		cf.LogStderr = opts.TransportStderr
+		cf.LogConfigSet = true
+		if opts.URLOnly {
+			cf.LogStdout = false
+			cf.LogStderr = false
+		}
 	}
 
 	rt, err := runtime.New(opts.RuntimeName)

--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -16,10 +16,10 @@ import (
 // Cloudflared uses the cloudflared quick-tunnel feature to expose a local URL.
 // The cloudflared binary must be available on PATH.
 type Cloudflared struct {
-	CommandLog io.Writer
-	ExtraArgs  []string
-	LogStdout  bool
-	LogStderr  bool
+	CommandLog   io.Writer
+	ExtraArgs    []string
+	LogStdout    bool
+	LogStderr    bool
 	LogConfigSet bool
 }
 

--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -18,6 +18,9 @@ import (
 type Cloudflared struct {
 	CommandLog io.Writer
 	ExtraArgs  []string
+	LogStdout  bool
+	LogStderr  bool
+	LogConfigSet bool
 }
 
 // tunnelURLRe matches the public URL printed by cloudflared logs.
@@ -67,11 +70,13 @@ func (c *Cloudflared) Expose(ctx context.Context, localURL string, urlCh chan<- 
 		outputCapture.WriteByte('\n')
 	}
 
-	scanOutput := func(r io.Reader) {
+	scanOutput := func(r io.Reader, shouldLog bool) {
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
 			line := scanner.Text()
-			fmt.Fprintf(c.commandLogWriter(), "cloudflared: %s\n", line)
+			if shouldLog {
+				fmt.Fprintf(c.commandLogWriter(), "cloudflared: %s\n", line)
+			}
 			appendCapture(line)
 			if m := tunnelURLRe.FindString(line); m != "" {
 				select {
@@ -86,11 +91,11 @@ func (c *Cloudflared) Expose(ctx context.Context, localURL string, urlCh chan<- 
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		scanOutput(stdout)
+		scanOutput(stdout, c.logStdoutEnabled())
 	}()
 	go func() {
 		defer wg.Done()
-		scanOutput(stderr)
+		scanOutput(stderr, c.logStderrEnabled())
 	}()
 
 	scanDoneCh := make(chan struct{})
@@ -162,4 +167,20 @@ func (c *Cloudflared) commandLogWriter() io.Writer {
 		return os.Stdout
 	}
 	return c.CommandLog
+}
+
+func (c *Cloudflared) logStdoutEnabled() bool {
+	if !c.LogConfigSet {
+		// Default behavior when not configured explicitly: print both streams.
+		return true
+	}
+	return c.LogStdout
+}
+
+func (c *Cloudflared) logStderrEnabled() bool {
+	if !c.LogConfigSet {
+		// Default behavior when not configured explicitly: print both streams.
+		return true
+	}
+	return c.LogStderr
 }

--- a/internal/transport/cloudflared_test.go
+++ b/internal/transport/cloudflared_test.go
@@ -44,3 +44,33 @@ func TestCloudflaredBuildArgs_UnixOrigin(t *testing.T) {
 		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
 	}
 }
+
+func TestCloudflaredLogEnable_DefaultsToBothStreams(t *testing.T) {
+	c := &Cloudflared{}
+	if !c.logStdoutEnabled() {
+		t.Fatal("expected stdout logging enabled by default")
+	}
+	if !c.logStderrEnabled() {
+		t.Fatal("expected stderr logging enabled by default")
+	}
+}
+
+func TestCloudflaredLogEnable_ExplicitValues(t *testing.T) {
+	c := &Cloudflared{LogStdout: true, LogStderr: false, LogConfigSet: true}
+	if !c.logStdoutEnabled() {
+		t.Fatal("expected stdout logging enabled")
+	}
+	if c.logStderrEnabled() {
+		t.Fatal("expected stderr logging disabled")
+	}
+}
+
+func TestCloudflaredLogEnable_ExplicitDisableBoth(t *testing.T) {
+	c := &Cloudflared{LogStdout: false, LogStderr: false, LogConfigSet: true}
+	if c.logStdoutEnabled() {
+		t.Fatal("expected stdout logging disabled")
+	}
+	if c.logStderrEnabled() {
+		t.Fatal("expected stderr logging disabled")
+	}
+}


### PR DESCRIPTION
## Summary
- add --transport-stdout and --transport-stderr CLI flags
- propagate stream output settings from CLI to cloudflared transport
- control cloudflared stdout/stderr console output independently while keeping output capture for diagnostics
- add tests for default and explicit stream logging behavior

## Scope
- cmd/qrrun/main.go
- internal/app/app.go
- internal/transport/cloudflared.go
- internal/transport/cloudflared_test.go