### PR TITLE
Fix unix origin handling by using --unix-socket

### DIFF
--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -155,8 +155,9 @@ func (c *Cloudflared) buildArgs(localURL string) []string {
 		args = append(args, c.ExtraArgs...)
 	}
 	if strings.HasPrefix(localURL, "unix://") {
-		// Keep unix URL as-is (unix:///path) to avoid it being interpreted as http://unix:/path.
-		return append(args, "--url", localURL)
+		socketPath := strings.TrimPrefix(localURL, "unix://")
+		// cloudflared expects --unix-socket instead of --url for unix origins.
+		return append(args, "--unix-socket", socketPath)
 	}
 	return append(args, "--url", localURL)
 }

--- a/internal/transport/cloudflared_test.go
+++ b/internal/transport/cloudflared_test.go
@@ -39,7 +39,7 @@ func TestCloudflaredBuildArgs_WithExtraOptions(t *testing.T) {
 func TestCloudflaredBuildArgs_UnixOrigin(t *testing.T) {
 	c := &Cloudflared{ExtraArgs: []string{"--loglevel", "debug"}}
 	got := c.buildArgs("unix:///tmp/qrrun.sock")
-	want := []string{"tunnel", "--loglevel", "debug", "--url", "unix:///tmp/qrrun.sock"}
+	want := []string{"tunnel", "--loglevel", "debug", "--unix-socket", "/tmp/qrrun.sock"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
 	}


### PR DESCRIPTION
## Summary
- re-check cloudflared tunnel help and apply unix-origin handling accordingly
- use --unix-socket <path> for unix:// origins instead of passing unix URL via --url
- prevent malformed origin resolution like http://unix:/... and lookup unix DNS errors
- update transport args test expectation

## Scope
- internal/transport/cloudflared.go
- internal/transport/cloudflared_test.go