### PR TITLE
Set transport stream output flags default to off

### DIFF
--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -87,10 +87,10 @@ Examples:
 		`Tunnel transport to use. Available: cloudflared`)
 	cmd.Flags().StringVar(&transportOpts, "transport-opts", "",
 		`Extra options passed to the selected transport command (example: --transport-opts='--loglevel debug').`)
-	cmd.Flags().BoolVar(&transportStderr, "transport-stderr", true,
-		`Print transport stderr output to console.`)
-	cmd.Flags().BoolVar(&transportStdout, "transport-stdout", true,
-		`Print transport stdout output to console.`)
+	cmd.Flags().BoolVar(&transportStderr, "transport-stderr", false,
+		`Enable transport stderr output to console.`)
+	cmd.Flags().BoolVar(&transportStdout, "transport-stdout", false,
+		`Enable transport stdout output to console.`)
 	cmd.Flags().BoolVar(&urlOnly, "url-only", false,
 		`Print only the runtime URL as a single line (no QR code or status text).`)
 


### PR DESCRIPTION
## Summary
- keep --transport-stdout and --transport-stderr as boolean flags
- change both flags to default OFF
- update help descriptions to clarify they enable output when set

## Scope
- cmd/qrrun/main.go