### PR TITLE
Use TCP origin hosting on all platforms

### DIFF
--- a/internal/server/listener_unix.go
+++ b/internal/server/listener_unix.go
@@ -5,36 +5,19 @@ package server
 import (
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 )
 
 func newOriginListener() (net.Listener, string, string, func(), error) {
-	socketDir, err := os.MkdirTemp("", "qrrun-sock-*")
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		return nil, "", "", nil, fmt.Errorf("server: create socket dir: %w", err)
-	}
-	if err := os.Chmod(socketDir, 0o700); err != nil {
-		_ = os.RemoveAll(socketDir)
-		return nil, "", "", nil, fmt.Errorf("server: chmod socket dir: %w", err)
-	}
-
-	socketPath := filepath.Join(socketDir, "origin.sock")
-	ln, err := net.Listen("unix", socketPath)
-	if err != nil {
-		_ = os.RemoveAll(socketDir)
 		return nil, "", "", nil, fmt.Errorf("server: listen: %w", err)
 	}
-	if err := os.Chmod(socketPath, 0o600); err != nil {
-		_ = ln.Close()
-		_ = os.RemoveAll(socketDir)
-		return nil, "", "", nil, fmt.Errorf("server: chmod socket: %w", err)
-	}
+
+	base := "http://" + ln.Addr().String()
 
 	cleanup := func() {
-		_ = os.Remove(socketPath)
-		_ = os.RemoveAll(socketDir)
+		_ = ln.Close()
 	}
 
-	return ln, "http://localhost", "unix://" + socketPath, cleanup, nil
+	return ln, base, base, cleanup, nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -66,20 +65,11 @@ func TestServer_URLFormat(t *testing.T) {
 		t.Fatalf("server.New: %v", err)
 	}
 
-	if runtime.GOOS == "windows" {
-		if !strings.HasPrefix(srv.URL(), "http://127.0.0.1:") {
-			t.Errorf("unexpected URL: %q", srv.URL())
-		}
-		if !strings.HasPrefix(srv.OriginURL(), "http://127.0.0.1:") {
-			t.Errorf("unexpected OriginURL: %q", srv.OriginURL())
-		}
-	} else {
-		if srv.URL() != "http://localhost" {
-			t.Errorf("unexpected URL: %q", srv.URL())
-		}
-		if !strings.HasPrefix(srv.OriginURL(), "unix://") {
-			t.Errorf("unexpected OriginURL: %q", srv.OriginURL())
-		}
+	if !strings.HasPrefix(srv.URL(), "http://127.0.0.1:") {
+		t.Errorf("unexpected URL: %q", srv.URL())
+	}
+	if !strings.HasPrefix(srv.OriginURL(), "http://127.0.0.1:") {
+		t.Errorf("unexpected OriginURL: %q", srv.OriginURL())
 	}
 
 	scriptURL := srv.ScriptURL()

--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -154,11 +154,6 @@ func (c *Cloudflared) buildArgs(localURL string) []string {
 	if len(c.ExtraArgs) > 0 {
 		args = append(args, c.ExtraArgs...)
 	}
-	if strings.HasPrefix(localURL, "unix://") {
-		socketPath := strings.TrimPrefix(localURL, "unix://")
-		// cloudflared expects --unix-socket instead of --url for unix origins.
-		return append(args, "--unix-socket", socketPath)
-	}
 	return append(args, "--url", localURL)
 }
 

--- a/internal/transport/cloudflared_test.go
+++ b/internal/transport/cloudflared_test.go
@@ -36,10 +36,10 @@ func TestCloudflaredBuildArgs_WithExtraOptions(t *testing.T) {
 	}
 }
 
-func TestCloudflaredBuildArgs_UnixOrigin(t *testing.T) {
+func TestCloudflaredBuildArgs_LocalhostURL(t *testing.T) {
 	c := &Cloudflared{ExtraArgs: []string{"--loglevel", "debug"}}
-	got := c.buildArgs("unix:///tmp/qrrun.sock")
-	want := []string{"tunnel", "--loglevel", "debug", "--unix-socket", "/tmp/qrrun.sock"}
+	got := c.buildArgs("http://127.0.0.1:54321")
+	want := []string{"tunnel", "--loglevel", "debug", "--url", "http://127.0.0.1:54321"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
 	}


### PR DESCRIPTION
## Summary
- remove unix socket origin listener on non-Windows and use localhost TCP listener instead
- simplify cloudflared transport args to always use --url with local TCP origin
- update server/transport tests to match TCP-only behavior

## Scope
- internal/server/listener_unix.go
- internal/server/server_test.go
- internal/transport/cloudflared.go
- internal/transport/cloudflared_test.go