### PR TITLE
Enable HTTPS origin with per-run self-signed cert

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -98,6 +99,27 @@ func Run(opts Options) error {
 	srv, err := server.New(scriptBytes, "text/x-python; charset=utf-8", bearerToken, requestLog)
 	if err != nil {
 		return err
+	}
+
+	if cf, ok := t.(*transport.Cloudflared); ok {
+		caPEM := srv.OriginCAPEM()
+		if len(caPEM) > 0 {
+			caFile, err := os.CreateTemp("", "qrrun-origin-ca-*.pem")
+			if err != nil {
+				return fmt.Errorf("create origin ca file: %w", err)
+			}
+			defer func() {
+				_ = os.Remove(caFile.Name())
+			}()
+			if _, err := caFile.Write(caPEM); err != nil {
+				_ = caFile.Close()
+				return fmt.Errorf("write origin ca file: %w", err)
+			}
+			if err := caFile.Close(); err != nil {
+				return fmt.Errorf("close origin ca file: %w", err)
+			}
+			cf.OriginCAPoolPath = caFile.Name()
+		}
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -247,20 +269,15 @@ func loadScriptContent(scriptPath string, input io.Reader) ([]byte, error) {
 
 // replaceBase swaps the local base URL in rawURL with publicBase.
 func replaceBase(rawURL, publicBase string) string {
-	// rawURL starts with the local server URL (e.g. "http://127.0.0.1:PORT/…").
-	// We swap the scheme+host+port portion with publicBase.
-	const scheme = "http://"
-	if len(rawURL) < len(scheme) {
+	rawParsed, err := url.Parse(rawURL)
+	if err != nil {
 		return rawURL
 	}
-	// Find end of host:port
-	rest := rawURL[len(scheme):]
-	slashIdx := len(rest)
-	for i, c := range rest {
-		if c == '/' {
-			slashIdx = i
-			break
-		}
+	publicParsed, err := url.Parse(publicBase)
+	if err != nil {
+		return rawURL
 	}
-	return publicBase + rest[slashIdx:]
+	rawParsed.Scheme = publicParsed.Scheme
+	rawParsed.Host = publicParsed.Host
+	return rawParsed.String()
 }

--- a/internal/server/listener_unix.go
+++ b/internal/server/listener_unix.go
@@ -14,6 +14,7 @@ func newOriginListener() (net.Listener, string, string, func(), error) {
 	}
 
 	base := "http://" + ln.Addr().String()
+	base = "https://" + ln.Addr().String()
 
 	cleanup := func() {
 		_ = ln.Close()

--- a/internal/server/listener_unix.go
+++ b/internal/server/listener_unix.go
@@ -13,8 +13,7 @@ func newOriginListener() (net.Listener, string, string, func(), error) {
 		return nil, "", "", nil, fmt.Errorf("server: listen: %w", err)
 	}
 
-	base := "http://" + ln.Addr().String()
-	base = "https://" + ln.Addr().String()
+	base := "https://" + ln.Addr().String()
 
 	cleanup := func() {
 		_ = ln.Close()

--- a/internal/server/listener_windows.go
+++ b/internal/server/listener_windows.go
@@ -13,7 +13,7 @@ func newOriginListener() (net.Listener, string, string, func(), error) {
 		return nil, "", "", nil, fmt.Errorf("server: listen: %w", err)
 	}
 
-	base := "http://" + ln.Addr().String()
+	base := "https://" + ln.Addr().String()
 	cleanup := func() {
 		_ = ln.Close()
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,15 +5,22 @@ package server
 import (
 	"context"
 	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/hex"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"net/http"
 	"os"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Server is an in-memory single-script HTTP server.
@@ -24,6 +31,8 @@ type Server struct {
 	contentType string
 	requestLog  io.Writer
 	listener    net.Listener
+	tlsConfig   *tls.Config
+	originCAPEM []byte
 	baseURL     string
 	originURL   string
 	cleanup     func()
@@ -46,6 +55,12 @@ func New(scriptBytes []byte, contentType string, bearerToken string, requestLog 
 		requestLog = os.Stdout
 	}
 
+	tlsConfig, caPEM, err := newOriginTLSConfig()
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+
 	scriptID, err := newScriptID()
 	if err != nil {
 		return nil, fmt.Errorf("server: script id: %w", err)
@@ -58,6 +73,8 @@ func New(scriptBytes []byte, contentType string, bearerToken string, requestLog 
 		contentType: contentType,
 		requestLog:  requestLog,
 		listener:    ln,
+		tlsConfig:   tlsConfig,
+		originCAPEM: caPEM,
 		baseURL:     baseURL,
 		originURL:   originURL,
 		cleanup:     cleanup,
@@ -74,6 +91,11 @@ func (s *Server) URL() string {
 // OriginURL returns the local origin URL for cloudflared.
 func (s *Server) OriginURL() string {
 	return s.originURL
+}
+
+// OriginCAPEM returns the PEM-encoded CA certificate used by the local origin.
+func (s *Server) OriginCAPEM() []byte {
+	return append([]byte(nil), s.originCAPEM...)
 }
 
 // ScriptURL returns the full URL for the served script file.
@@ -129,9 +151,10 @@ func (s *Server) Serve(ctx context.Context) error {
 
 	srv := &http.Server{Handler: mux}
 
+	tlsListener := tls.NewListener(s.listener, s.tlsConfig)
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- srv.Serve(s.listener)
+		errCh <- srv.Serve(tlsListener)
 	}()
 
 	select {
@@ -154,4 +177,47 @@ func newScriptID() (string, error) {
 	}
 	// 32 hex chars, extensionless UUID-like identifier suitable for URL path.
 	return hex.EncodeToString(raw), nil
+}
+
+func newOriginTLSConfig() (*tls.Config, []byte, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, fmt.Errorf("server: generate tls key: %w", err)
+	}
+
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("server: generate tls serial: %w", err)
+	}
+
+	now := time.Now().UTC()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: "qrrun-origin",
+		},
+		NotBefore:             now.Add(-5 * time.Minute),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("server: create tls cert: %w", err)
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, nil, fmt.Errorf("server: load tls keypair: %w", err)
+	}
+
+	return &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}, certPEM, nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,9 +3,10 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -37,7 +38,7 @@ func TestServer_ServesScriptFile(t *testing.T) {
 	// Give the server a moment to start.
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := doRequest(serverHTTPClient(srv.OriginURL()), http.MethodGet, srv.ScriptURL(), testBearerToken, nil)
+	resp, err := doRequest(serverHTTPClient(srv), http.MethodGet, srv.ScriptURL(), testBearerToken, nil)
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
@@ -65,10 +66,10 @@ func TestServer_URLFormat(t *testing.T) {
 		t.Fatalf("server.New: %v", err)
 	}
 
-	if !strings.HasPrefix(srv.URL(), "http://127.0.0.1:") {
+	if !strings.HasPrefix(srv.URL(), "https://127.0.0.1:") {
 		t.Errorf("unexpected URL: %q", srv.URL())
 	}
-	if !strings.HasPrefix(srv.OriginURL(), "http://127.0.0.1:") {
+	if !strings.HasPrefix(srv.OriginURL(), "https://127.0.0.1:") {
 		t.Errorf("unexpected OriginURL: %q", srv.OriginURL())
 	}
 
@@ -107,7 +108,7 @@ func TestServer_FirstRequestServed_IsSignaled(t *testing.T) {
 	default:
 	}
 
-	resp, err := doRequest(serverHTTPClient(srv.OriginURL()), http.MethodGet, srv.ScriptURL(), testBearerToken, nil)
+	resp, err := doRequest(serverHTTPClient(srv), http.MethodGet, srv.ScriptURL(), testBearerToken, nil)
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
@@ -140,7 +141,7 @@ func TestServer_FirstRequestServed_HeadDoesNotSignal(t *testing.T) {
 		t.Fatalf("create HEAD request: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+testBearerToken)
-	resp, err := serverHTTPClient(srv.OriginURL()).Do(req)
+	resp, err := serverHTTPClient(srv).Do(req)
 	if err != nil {
 		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
 	}
@@ -169,7 +170,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	if _, err := doRequest(serverHTTPClient(srv.OriginURL()), http.MethodGet, srv.ScriptURL(), testBearerToken, nil); err != nil {
+	if _, err := doRequest(serverHTTPClient(srv), http.MethodGet, srv.ScriptURL(), testBearerToken, nil); err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
 
@@ -178,7 +179,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 		t.Fatalf("create HEAD request: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+testBearerToken)
-	resp, err := serverHTTPClient(srv.OriginURL()).Do(req)
+	resp, err := serverHTTPClient(srv).Do(req)
 	if err != nil {
 		t.Fatalf("HEAD %s: %v", srv.ScriptURL(), err)
 	}
@@ -189,7 +190,7 @@ func TestServer_LogsAllRequests(t *testing.T) {
 		t.Fatalf("create POST request: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+testBearerToken)
-	resp, err = serverHTTPClient(srv.OriginURL()).Do(req)
+	resp, err = serverHTTPClient(srv).Do(req)
 	if err != nil {
 		t.Fatalf("POST %s: %v", srv.ScriptURL(), err)
 	}
@@ -222,7 +223,7 @@ func TestServer_RejectsUnauthorizedRequest(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := doRequest(serverHTTPClient(srv.OriginURL()), http.MethodGet, srv.ScriptURL(), "wrong-token", nil)
+	resp, err := doRequest(serverHTTPClient(srv), http.MethodGet, srv.ScriptURL(), "wrong-token", nil)
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
@@ -248,15 +249,13 @@ func doRequest(client *http.Client, method, url, bearerToken string, body io.Rea
 	return client.Do(req)
 }
 
-func serverHTTPClient(originURL string) *http.Client {
-	if strings.HasPrefix(originURL, "unix://") {
-		socketPath := strings.TrimPrefix(originURL, "unix://")
-		tr := &http.Transport{
-			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
-			},
-		}
-		return &http.Client{Transport: tr}
+func serverHTTPClient(srv *server.Server) *http.Client {
+	pool := x509.NewCertPool()
+	if ok := pool.AppendCertsFromPEM(srv.OriginCAPEM()); !ok {
+		panic("failed to append origin CA cert")
 	}
-	return http.DefaultClient
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool},
+	}
+	return &http.Client{Transport: tr}
 }

--- a/internal/transport/cloudflared.go
+++ b/internal/transport/cloudflared.go
@@ -16,11 +16,12 @@ import (
 // Cloudflared uses the cloudflared quick-tunnel feature to expose a local URL.
 // The cloudflared binary must be available on PATH.
 type Cloudflared struct {
-	CommandLog   io.Writer
-	ExtraArgs    []string
-	LogStdout    bool
-	LogStderr    bool
-	LogConfigSet bool
+	CommandLog       io.Writer
+	ExtraArgs        []string
+	OriginCAPoolPath string
+	LogStdout        bool
+	LogStderr        bool
+	LogConfigSet     bool
 }
 
 // tunnelURLRe matches the public URL printed by cloudflared logs.
@@ -153,6 +154,9 @@ func (c *Cloudflared) buildArgs(localURL string) []string {
 	args := []string{"tunnel"}
 	if len(c.ExtraArgs) > 0 {
 		args = append(args, c.ExtraArgs...)
+	}
+	if strings.TrimSpace(c.OriginCAPoolPath) != "" {
+		args = append(args, "--origin-ca-pool", c.OriginCAPoolPath)
 	}
 	return append(args, "--url", localURL)
 }

--- a/internal/transport/cloudflared_test.go
+++ b/internal/transport/cloudflared_test.go
@@ -36,6 +36,15 @@ func TestCloudflaredBuildArgs_WithExtraOptions(t *testing.T) {
 	}
 }
 
+func TestCloudflaredBuildArgs_WithOriginCAPool(t *testing.T) {
+	c := &Cloudflared{OriginCAPoolPath: "/tmp/qrrun-origin-ca.pem"}
+	got := c.buildArgs("https://127.0.0.1:12345")
+	want := []string{"tunnel", "--origin-ca-pool", "/tmp/qrrun-origin-ca.pem", "--url", "https://127.0.0.1:12345"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected args: got %#v, want %#v", got, want)
+	}
+}
+
 func TestCloudflaredBuildArgs_LocalhostURL(t *testing.T) {
 	c := &Cloudflared{ExtraArgs: []string{"--loglevel", "debug"}}
 	got := c.buildArgs("http://127.0.0.1:54321")


### PR DESCRIPTION
## Summary
- generate a self-signed certificate in memory on each server startup
- serve local origin over HTTPS instead of plain HTTP
- provide cloudflared with an origin CA pool file for trusting only the generated self-signed certificate
- update URL replacement logic for non-http schemes and test clients to trust origin CA in tests

## Scope
- internal/server/server.go
- internal/server/listener_unix.go
- internal/server/listener_windows.go
- internal/server/server_test.go
- internal/app/app.go
- internal/transport/cloudflared.go
- internal/transport/cloudflared_test.go

## Note
- cloudflared currently accepts origin CA via file path, so CA PEM is written to a temporary file and removed after use