### PR TITLE
Fix Pythonista exec query space encoding

### DIFF
--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 )
 
 // Pythonista produces URLs for Pythonista runtimes.
@@ -13,5 +15,6 @@ type Pythonista struct {
 // QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
 func (p *Pythonista) QRCodeURL(publicURL string, bearerToken string) string {
 	code := fmt.Sprintf("exec(__import__(\"requests\").get(%q,headers={\"Authorization\":\"Bearer %s\"}).text)", publicURL, bearerToken)
-	return fmt.Sprintf("%s://?exec=%s", p.Scheme, code)
+	encoded := strings.ReplaceAll(url.QueryEscape(code), "+", " ")
+	return fmt.Sprintf("%s://?exec=%s", p.Scheme, encoded)
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,6 +1,7 @@
 package runtime_test
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -56,9 +57,13 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 			t.Errorf("expected %q prefix for %q, got %q", prefix, tc.name, got)
 		}
 
-		execCode := strings.TrimPrefix(got, prefix)
-		if execCode == "" {
+		rawExec := strings.TrimPrefix(got, prefix)
+		if rawExec == "" {
 			t.Errorf("expected exec query parameter for %q, got %q", tc.name, got)
+		}
+		execCode, err := url.QueryUnescape(rawExec)
+		if err != nil {
+			t.Fatalf("failed to decode exec code for %q: %v (raw: %q)", tc.name, err, rawExec)
 		}
 		if !strings.HasPrefix(execCode, "exec(__import__(\"requests\").get(") {
 			t.Errorf("expected single-expression __import__ prefix in exec code for %q, got %q", tc.name, execCode)
@@ -75,8 +80,14 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		if !strings.Contains(execCode, rawURL) {
 			t.Errorf("expected raw URL in exec code for %q, got %q", tc.name, execCode)
 		}
-		if strings.Contains(execCode, "%") {
-			t.Errorf("expected unencoded exec code for %q, got %q", tc.name, execCode)
+		if !strings.Contains(rawExec, "%") {
+			t.Errorf("expected encoded exec query for %q, got %q", tc.name, rawExec)
+		}
+		if strings.Contains(rawExec, "+") {
+			t.Errorf("expected spaces to remain literal spaces (no '+') for %q, got %q", tc.name, rawExec)
+		}
+		if !strings.Contains(rawExec, " ") {
+			t.Errorf("expected raw exec query to contain a literal space for %q, got %q", tc.name, rawExec)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- keep `exec` query URL-encoded for Pythonista deep links
- preserve literal spaces in the encoded query by replacing `+` with a space
- update runtime tests to validate decode behavior and no `+` for spaces

## Testing
- go test ./internal/runtime/...
- go test ./...
