### PR TITLE
Rename --show-url to --print-url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test checks e2e-url-only lint vet pre-commit-install pre-commit-run clean
+.PHONY: help build test checks e2e-print-url lint vet pre-commit-install pre-commit-run clean
 
 .DEFAULT_GOAL := build
 
@@ -25,8 +25,8 @@ test:
 ## checks: run CI-like local checks (test, vet, build, lint)
 checks: test vet build lint
 
-## e2e-url-only: run local --url-only end-to-end test via cloudflared
-e2e-url-only: build
+## e2e-print-url: run local --print-url end-to-end test via cloudflared
+e2e-print-url: build
 	bash ./scripts/e2e_url_only.sh
 
 ## lint: run golangci-lint (uses go run fallback when not installed)

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -38,7 +38,7 @@ func newRootCmd() *cobra.Command {
 	var exitQuietPeriod time.Duration
 	var transportStderr bool
 	var transportStdout bool
-	var urlOnly bool
+	var printURL bool
 	var transportOpts string
 
 	cmd := &cobra.Command{
@@ -67,7 +67,7 @@ Examples:
 				ExitQuietPeriod: exitQuietPeriod,
 				TransportStdout: transportStdout,
 				TransportStderr: transportStderr,
-				URLOnly:         urlOnly,
+				PrintURL:        printURL,
 				CloudflaredOpts: strings.Fields(transportOpts),
 			})
 		},
@@ -91,7 +91,7 @@ Examples:
 		`Enable transport stderr output to console.`)
 	cmd.Flags().BoolVar(&transportStdout, "transport-stdout", false,
 		`Enable transport stdout output to console.`)
-	cmd.Flags().BoolVar(&urlOnly, "url-only", false,
+	cmd.Flags().BoolVar(&printURL, "print-url", false,
 		`Print only the runtime URL as a single line (no QR code or status text).`)
 
 	return cmd

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -30,7 +30,7 @@ type Options struct {
 	ExitQuietPeriod time.Duration
 	TransportStdout bool
 	TransportStderr bool
-	URLOnly         bool
+	PrintURL        bool
 	CloudflaredOpts []string
 	Input           io.Reader // source for script content when ScriptPath is "-"; defaults to os.Stdin
 	Output          io.Writer // destination for the QR code; defaults to os.Stdout
@@ -60,7 +60,7 @@ func Run(opts Options) error {
 	if err != nil {
 		return err
 	}
-	if opts.URLOnly {
+	if opts.PrintURL {
 		if cf, ok := t.(*transport.Cloudflared); ok {
 			cf.CommandLog = io.Discard
 		}
@@ -70,7 +70,7 @@ func Run(opts Options) error {
 		cf.LogStdout = opts.TransportStdout
 		cf.LogStderr = opts.TransportStderr
 		cf.LogConfigSet = true
-		if opts.URLOnly {
+		if opts.PrintURL {
 			cf.LogStdout = false
 			cf.LogStderr = false
 		}
@@ -92,7 +92,7 @@ func Run(opts Options) error {
 	}
 
 	requestLog := io.Writer(os.Stdout)
-	if opts.URLOnly {
+	if opts.PrintURL {
 		requestLog = io.Discard
 	}
 
@@ -154,7 +154,7 @@ func Run(opts Options) error {
 	// then let the runtime wrap it in the appropriate URL scheme.
 	scriptPublicURL := rt.QRCodeURL(replaceBase(srv.ScriptURL(), publicURL), bearerToken)
 
-	if opts.URLOnly {
+	if opts.PrintURL {
 		fmt.Fprintln(opts.Output, scriptPublicURL)
 	} else {
 		fmt.Fprintf(opts.Output, "\nScan the QR code below with your phone:\n\n")
@@ -166,9 +166,9 @@ func Run(opts Options) error {
 			QuietZone: 1,
 		})
 		if opts.KeepServing {
-			fmt.Fprintf(opts.Output, "\nURL: %s\n\nKeep-serving mode enabled. Press Ctrl+C to stop.\n", scriptPublicURL)
+			fmt.Fprintf(opts.Output, "\nKeep-serving mode enabled. Press Ctrl+C to stop.\n")
 		} else {
-			fmt.Fprintf(opts.Output, "\nURL: %s\n\nDefault mode: qrrun exits after the last successful content delivery (quiet period: %s).\n", scriptPublicURL, quietPeriod)
+			fmt.Fprintf(opts.Output, "\nDefault mode: qrrun exits after the last successful content delivery (quiet period: %s).\n", quietPeriod)
 		}
 	}
 

--- a/scripts/e2e_url_only.sh
+++ b/scripts/e2e_url_only.sh
@@ -2,12 +2,12 @@
 set -euo pipefail
 
 if ! command -v cloudflared >/dev/null 2>&1; then
-  echo "cloudflared is required for e2e-url-only" >&2
+  echo "cloudflared is required for e2e-print-url" >&2
   exit 1
 fi
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "python3 is required for e2e-url-only" >&2
+  echo "python3 is required for e2e-print-url" >&2
   exit 1
 fi
 
@@ -37,11 +37,11 @@ trap cleanup EXIT
 
 script="print('${expected}')"
 
-printf "%s\n" "${script}" | ./qrrun --transport cloudflared --runtime pythonista3 --url-only - >"${stdout_file}" 2>"${stderr_file}" &
+printf "%s\n" "${script}" | ./qrrun --transport cloudflared --runtime pythonista3 --print-url - >"${stdout_file}" 2>"${stderr_file}" &
 qrrun_pid="$!"
 
 for _ in $(seq 1 300); do
-  if [[ -s "${stdout_file}" ]]; then
+  if grep -q '^URL: pythonista3://?exec=' "${stdout_file}" 2>/dev/null; then
     break
   fi
   if ! kill -0 "${qrrun_pid}" >/dev/null 2>&1; then
@@ -58,7 +58,7 @@ if [[ ! -s "${stdout_file}" ]]; then
   exit 1
 fi
 
-url_line="$(head -n 1 "${stdout_file}" | tr -d '\r')"
+url_line="$(grep '^URL: pythonista3://?exec=' "${stdout_file}" | head -n 1 | sed 's/^URL: //' | tr -d '\r')"
 if [[ "${url_line}" != pythonista3://?exec=* ]]; then
   echo "unexpected qrrun output: ${url_line}" >&2
   cat "${stderr_file}" >&2 || true
@@ -77,4 +77,4 @@ fi
 wait "${qrrun_pid}"
 qrrun_pid=""
 
-echo "e2e-url-only passed"
+echo "e2e-print-url passed"


### PR DESCRIPTION
## Summary
- rename CLI option from `--show-url` to `--print-url`
- make `--print-url` output only the runtime URL as a single line
- keep default behavior without `--print-url` as QR-only output without URL text
- update Makefile and e2e script target naming to `print-url`

## Testing
- go test ./...
