### PR TITLE
Rename product text to QRrun

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# qrrun
+# QRrun
 [![CI](https://github.com/sakurai-youhei/qrrun/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sakurai-youhei/qrrun/actions/workflows/ci.yml)
 [![Release](https://github.com/sakurai-youhei/qrrun/actions/workflows/release.yml/badge.svg)](https://github.com/sakurai-youhei/qrrun/actions/workflows/release.yml)
 [![Latest Release](https://img.shields.io/github/v/release/sakurai-youhei/qrrun)](https://github.com/sakurai-youhei/qrrun/releases)
@@ -9,7 +9,7 @@ Tunnel local code. Run via QR.
 ## Prerequisites
 
 - `cloudflared` must be installed and available in your PATH.
-- `qrrun` uses Cloudflare Quick Tunnels (`trycloudflare.com`).
+- QRrun uses Cloudflare Quick Tunnels (`trycloudflare.com`).
 
 See [Cloudflare Quick Tunnel documentation](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/trycloudflare/) for details.
 
@@ -27,7 +27,7 @@ Run from stdin (`-`):
 echo "print('hello from stdin')" | qrrun -
 ```
 
-By default, `qrrun` generates a QR code for opening and running your script in Pythonista3 via Cloudflare Quick Tunnels, unless you explicitly override `--transport` or `--runtime`.
+By default, QRrun generates a QR code for opening and running your script in Pythonista3 via Cloudflare Quick Tunnels, unless you explicitly override `--transport` or `--runtime`.
 For more options and behavior details, run `qrrun --help`.
 
 ## Installation

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -45,13 +45,13 @@ func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "qrrun [flags] <script|-]",
 		Short: "tunnel local scripts and run via QR",
-		Long: `qrrun serves a local script through a secure tunnel and prints a QR code.
+		Long: `QRrun serves a local script through a secure tunnel and prints a QR code.
 
 scan the QR code to open the script in the selected runtime.
 
 Prerequisites:
 	cloudflared must be installed and available on PATH
-	qrrun uses Cloudflare Quick Tunnels (trycloudflare.com)
+	QRrun uses Cloudflare Quick Tunnels (trycloudflare.com)
 
 Examples:
 	qrrun hello.py

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sakurai-youhei/qrrun/internal/transport"
 )
 
-// Options holds the configuration for a single qrrun invocation.
+// Options holds the configuration for a single QRrun invocation.
 type Options struct {
 	TransportName   string
 	RuntimeName     string
@@ -39,7 +39,7 @@ type Options struct {
 
 const DefaultExitQuietPeriod = 500 * time.Millisecond
 
-// Run performs the full qrrun workflow:
+// Run performs the full QRrun workflow:
 //  1. Validates options and resolves the transport / runtime.
 //  2. Starts a local HTTP server to serve the script.
 //  3. Starts the tunnel via the chosen transport.
@@ -168,7 +168,7 @@ func Run(opts Options) error {
 		if opts.KeepServing {
 			fmt.Fprintf(statusOutput, "\nKeep-serving mode enabled. Press Ctrl+C to stop.\n")
 		} else {
-			fmt.Fprintf(statusOutput, "\nDefault mode: qrrun exits after the last successful content delivery (quiet period: %s).\n", quietPeriod)
+			fmt.Fprintf(statusOutput, "\nDefault mode: QRrun exits after the last successful content delivery (quiet period: %s).\n", quietPeriod)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- update product-name display text from `qrrun` to `QRrun`
- update README title and user-facing description text
- update CLI long help and status text references
- keep command/module identifiers unchanged

## Testing
- go test ./...
