### PR TITLE
Fix WiX install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Install WiX Toolset
         shell: powershell
         run: |
-          choco install wixtoolset --version=3.14.1 -y
+          choco install wixtoolset -y
           echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Build Windows binary and MSI


### PR DESCRIPTION
## Summary
- remove strict WiX version pin in release workflow
- allow preinstalled newer WiX versions on GitHub-hosted runners

## Reason
- release failed when a newer WiX was already installed and choco rejected downgrade