### PR TITLE
Enable linux arm64 RPM packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 #
 # Build output
 /qrrun
+/dist
 
 # Binaries for programs and plugins
 *.exe

--- a/scripts/release_package_rpm.sh
+++ b/scripts/release_package_rpm.sh
@@ -47,5 +47,8 @@ install -m 0755 %{SOURCE0} %{buildroot}/usr/bin/qrrun
 - Automated release build
 EOF
 
-rpmbuild --define "_topdir ${RPM_TOPDIR}" -bb "${RPM_TOPDIR}/SPECS/qrrun.spec"
+rpmbuild \
+  --target "${RPM_ARCH}" \
+  --define "_topdir ${RPM_TOPDIR}" \
+  -bb "${RPM_TOPDIR}/SPECS/qrrun.spec"
 find "${RPM_TOPDIR}/RPMS" -type f -name '*.rpm' -exec cp {} dist/ \;


### PR DESCRIPTION
## Summary
- keep RPM packaging enabled for linux arm64
- pass explicit rpmbuild target architecture for arm64 ()
- restore linux arm64 RPM artifact upload path
- ignore local  output directory

## Notes
- local reproduction previously failed before rpmbuild execution because the tool is not installed in this environment