### PR TITLE
Fix release MSI version handling and arm64 RPM packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,8 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y rpm
+          sudo apt-get install -y rpm ruby ruby-dev build-essential
+          sudo gem install --no-document fpm
 
       - name: Build binary and package
         shell: bash

--- a/scripts/release_build_windows_msi.ps1
+++ b/scripts/release_build_windows_msi.ps1
@@ -10,10 +10,24 @@ $env:CGO_ENABLED = "0"
 $env:GOOS = "windows"
 go build -trimpath -ldflags "-s -w -X 'main.version=${env:VERSION}' -X 'main.commit=${commit}' -X 'main.date=${date}'" -o "dist/${base}.exe" ./cmd/qrrun
 
-$productVersion = [regex]::Match($env:VERSION, '^[vV]?(\d+\.\d+\.\d+)').Groups[1].Value
-if ([string]::IsNullOrWhiteSpace($productVersion)) {
+$match = [regex]::Match($env:VERSION, '^[vV]?(\d+)\.(\d+)\.(\d+)(?:-[A-Za-z]+\.(\d+))?')
+if (-not $match.Success) {
   throw "Tag '$env:VERSION' must start with SemVer core (e.g. v1.2.3) for MSI versioning"
 }
 
-candle -nologo -arch $env:WIX_ARCH -dBinarySource="dist/${base}.exe" -dProductVersion=$productVersion -out "dist/${base}.wixobj" packaging/windows/qrrun.wxs
+$major = [int]$match.Groups[1].Value
+$minor = [int]$match.Groups[2].Value
+$patch = [int]$match.Groups[3].Value
+$build = 0
+if ($match.Groups[4].Success) {
+  $build = [int]$match.Groups[4].Value
+}
+
+$productVersion = "$major.$minor.$patch.$build"
+$wxsTemplate = Get-Content packaging/windows/qrrun.wxs -Raw
+$wxsRendered = $wxsTemplate.Replace('$(var.ProductVersion)', $productVersion).Replace('$(var.BinarySource)', "dist/${base}.exe")
+$wxsPath = "dist/${base}.wxs"
+Set-Content -Path $wxsPath -Value $wxsRendered -NoNewline
+
+candle -nologo -arch $env:WIX_ARCH -out "dist/${base}.wixobj" $wxsPath
 light -nologo -ext WixUIExtension -out "dist/${base}.msi" "dist/${base}.wixobj"

--- a/scripts/release_package_rpm.sh
+++ b/scripts/release_package_rpm.sh
@@ -12,43 +12,17 @@ fi
 RPM_VERSION="${DEB_VERSION%%-*}"
 RPM_RELEASE="1"
 if [ "${DEB_VERSION}" != "${RPM_VERSION}" ]; then
-  RPM_RELEASE="0.$(echo "${DEB_VERSION#${RPM_VERSION}-}" | tr -c '[:alnum:].' '.')"
+  RPM_RELEASE="0.$(echo "${DEB_VERSION#${RPM_VERSION}-}" | tr -c '[:alnum:].' '.' | sed 's/[.]\+$//')"
 fi
 
-RPM_TOPDIR="$PWD/dist/rpmbuild"
-mkdir -p "${RPM_TOPDIR}/BUILD" "${RPM_TOPDIR}/RPMS" "${RPM_TOPDIR}/SOURCES" "${RPM_TOPDIR}/SPECS" "${RPM_TOPDIR}/SRPMS"
-cp "dist/${BIN}" "${RPM_TOPDIR}/SOURCES/qrrun"
-
-cat > "${RPM_TOPDIR}/SPECS/qrrun.spec" <<EOF
-Name:           qrrun
-Version:        ${RPM_VERSION}
-Release:        ${RPM_RELEASE}
-Summary:        Tunnel local code and run it via QR
-License:        MIT
-BuildArch:      ${RPM_ARCH}
-Source0:        qrrun
-
-%description
-Tunnel local code and run it via QR.
-
-%prep
-
-%build
-
-%install
-mkdir -p %{buildroot}/usr/bin
-install -m 0755 %{SOURCE0} %{buildroot}/usr/bin/qrrun
-
-%files
-/usr/bin/qrrun
-
-%changelog
-* $(date -u '+%a %b %d %Y') qrrun maintainers - ${DEB_VERSION}
-- Automated release build
-EOF
-
-rpmbuild \
-  --target "${RPM_ARCH}" \
-  --define "_topdir ${RPM_TOPDIR}" \
-  -bb "${RPM_TOPDIR}/SPECS/qrrun.spec"
-find "${RPM_TOPDIR}/RPMS" -type f -name '*.rpm' -exec cp {} dist/ \;
+fpm \
+  -s dir \
+  -t rpm \
+  -n qrrun \
+  -v "${RPM_VERSION}" \
+  --iteration "${RPM_RELEASE}" \
+  --architecture "${RPM_ARCH}" \
+  --license MIT \
+  --description "Tunnel local code and run it via QR." \
+  --package "dist/qrrun_${DEB_VERSION}_${RPM_ARCH}.rpm" \
+  "dist/${BIN}=/usr/bin/qrrun"


### PR DESCRIPTION
## Summary\n- render WiX source with concrete ProductVersion/BinarySource values to avoid unresolved MSI version tokens\n- map prerelease tags (e.g. beta.3) to a valid MSI 4-part version\n- switch linux RPM packaging to fpm so arm64 RPM can be produced on amd64 runners\n- install fpm dependencies in release workflow\n\n## Why\nThe v0.1.0-beta.3 release run failed in two places:\n1. MSI build used an invalid Product version token\n2. arm64 RPM build failed with rpmbuild architecture compatibility errors\n\nThis change addresses both blockers for the next release tag.