### PR TITLE
Fix WiX component condition syntax for MSI build

### DIFF
--- a/packaging/windows/qrrun.wxs
+++ b/packaging/windows/qrrun.wxs
@@ -18,7 +18,8 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="WixPerMachineFolder">
         <Directory Id="INSTALLDIR_MACHINE" Name="qrrun">
-          <Component Id="QrrunMachine" Guid="*" Condition="ALLUSERS=1">
+          <Component Id="QrrunMachine" Guid="*">
+            <Condition>ALLUSERS=1</Condition>
             <File Id="QrrunExeMachine" Source="$(var.BinarySource)" KeyPath="yes" Name="qrrun.exe" />
             <Environment
               Id="PathMachine"
@@ -33,7 +34,8 @@
       </Directory>
       <Directory Id="WixPerUserFolder">
         <Directory Id="INSTALLDIR_USER" Name="qrrun">
-          <Component Id="QrrunUser" Guid="*" Condition="ALLUSERS&lt;&gt;1">
+          <Component Id="QrrunUser" Guid="*">
+            <Condition>ALLUSERS&lt;&gt;1</Condition>
             <File Id="QrrunExeUser" Source="$(var.BinarySource)" KeyPath="yes" Name="qrrun.exe" />
             <Environment
               Id="PathUser"


### PR DESCRIPTION
## Summary\n- replace invalid Component Condition attributes with child Condition elements\n- keep same machine/user install gating logic\n\n## Why\nrelease run for v0.1.0-beta.4 failed in both MSI jobs with:\n- CNDL0004: Component contains unexpected attribute 'Condition'\n\nThis makes the .wxs schema-compatible with WiX v3 used in CI.