### PR TITLE
Define ApplicationFolderName for WiX advanced UI

### DIFF
--- a/packaging/windows/qrrun.wxs
+++ b/packaging/windows/qrrun.wxs
@@ -12,6 +12,7 @@
     <MediaTemplate EmbedCab="yes" />
 
     <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
+    <Property Id="ApplicationFolderName" Value="qrrun" />
     <Property Id="WixUISupportPerUser" Value="1" />
     <Property Id="WixUISupportPerMachine" Value="1" />
 


### PR DESCRIPTION
## Summary\n- add ApplicationFolderName property required by WixUI_Advanced\n\n## Why\nrelease run for v0.1.0-beta.5 failed in MSI jobs with:\n- LGHT0094 unresolved symbol Property:ApplicationFolderName\n\nThis supplies the missing property expected by the WiX UI library.