### PR TITLE
Checkout repository in release workflow release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,9 @@ jobs:
       - build-msi
     if: needs.guard-main.outputs.on_main == 'true'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download all packaged artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary\n- add actions/checkout in release job before running script steps\n\n## Why\nThe v0.1.0-beta.7 release run failed in release job because:\n- ./scripts/release_generate_homebrew_formula.sh was not found\n\nThe release job downloaded artifacts but did not have repository scripts checked out.