### PR TITLE
Add Python artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,16 @@ go.work.sum
 # env file
 .env
 
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+venv/
+
 # Editor/IDE
 # .idea/
 # .vscode/


### PR DESCRIPTION
## Summary
- ignore Python cache artifacts and virtualenv directories
- keep repository clean when running Python-based tooling

## Added
- __pycache__/
- *.py[cod], *.pyo
- .pytest_cache/, .mypy_cache/, .ruff_cache/
- .venv/, venv/