### PR TITLE
Add pyproject-fmt and checkmake pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,16 @@ repos:
       - id: ruff-format
         files: \.py$
 
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.9.0
+    hooks:
+      - id: pyproject-fmt
+
+  - repo: https://github.com/checkmake/checkmake
+    rev: v0.3.2
+    hooks:
+      - id: checkmake
+
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.14.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.ruff]
 line-length = 79
 
-[tool.ruff.lint]
-select = ["E", "W", "F"]
+lint.select = [ "E", "F", "W" ]


### PR DESCRIPTION
## Summary
- add pyproject-fmt hook to pre-commit
- add checkmake hook to pre-commit
- include formatted Ruff section in pyproject.toml generated by pyproject-fmt

## Scope
- pre-commit-related additions only
