### PR TITLE
Mark release shell scripts executable for pre-commit

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,7 @@ arch="$(uname -m)"
 
 case "$arch" in
   x86_64) arch="amd64" ;;
-  aarch64|arm64) arch="arm64" ;;
+  aarch64 | arm64) arch="arm64" ;;
   *)
     echo "Unsupported architecture: $arch" >&2
     exit 1

--- a/scripts/release_generate_homebrew_formula.sh
+++ b/scripts/release_generate_homebrew_formula.sh
@@ -10,7 +10,7 @@ SHA_ARM64="$(sha256sum "dist/${DARWIN_ARM64}" | awk '{print $1}')"
 
 mkdir -p dist/homebrew
 
-cat > dist/homebrew/qrrun.rb <<EOF
+cat >dist/homebrew/qrrun.rb <<EOF
 class Qrrun < Formula
   desc "Tunnel local code and run it via QR"
   homepage "https://github.com/${REPO}"

--- a/scripts/release_package_deb.sh
+++ b/scripts/release_package_deb.sh
@@ -9,7 +9,7 @@ PKG_ROOT="dist/${DEB_BASE}"
 mkdir -p "${PKG_ROOT}/DEBIAN" "${PKG_ROOT}/usr/bin"
 install -m 0755 "dist/${BIN}" "${PKG_ROOT}/usr/bin/qrrun"
 
-cat > "${PKG_ROOT}/DEBIAN/control" <<EOF
+cat >"${PKG_ROOT}/DEBIAN/control" <<EOF
 Package: qrrun
 Version: ${DEB_VERSION}
 Section: utils

--- a/scripts/release_package_rpm.sh
+++ b/scripts/release_package_rpm.sh
@@ -12,7 +12,7 @@ fi
 RPM_VERSION="${DEB_VERSION%%-*}"
 RPM_RELEASE="1"
 if [ "${DEB_VERSION}" != "${RPM_VERSION}" ]; then
-  RPM_RELEASE="0.$(echo "${DEB_VERSION#${RPM_VERSION}-}" | tr -c '[:alnum:].' '.' | sed 's/[.]\+$//')"
+  RPM_RELEASE="0.$(echo "${DEB_VERSION#"${RPM_VERSION}"-}" | tr -c '[:alnum:].' '.' | sed 's/[.]\+$//')"
 fi
 
 fpm \


### PR DESCRIPTION
## Summary
- set executable bit on release shell scripts that already have shebangs
- satisfy pre-commit check-shebang-scripts-are-executable for sh files

## Files
- scripts/release_generate_homebrew_formula.sh
- scripts/release_package_deb.sh
- scripts/release_package_rpm.sh
