### PR TITLE
chore: tighten PowerShell checks

### DIFF
--- a/scripts/precommit_psscriptanalyzer.ps1
+++ b/scripts/precommit_psscriptanalyzer.ps1
@@ -18,7 +18,7 @@ Import-Module PSScriptAnalyzer
 $issues = @()
 foreach ($path in $Paths) {
   if (-not [string]::IsNullOrWhiteSpace($path)) {
-    $issues += Invoke-ScriptAnalyzer -Path $path -Severity Error,Warning
+    $issues += Invoke-ScriptAnalyzer -Path $path -Severity Error,Warning,Information
   }
 }
 

--- a/scripts/release_build_windows_msi.ps1
+++ b/scripts/release_build_windows_msi.ps1
@@ -1,18 +1,26 @@
 $ErrorActionPreference = 'Stop'
 
 $date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-$commit = "${env:GITHUB_SHA}".Substring(0, 7)
-$base = "qrrun_${env:VERSION}_windows_${env:GOARCH}"
+$githubSha = "${env:GITHUB_SHA}"
+$commit = "unknown"
+if (-not [string]::IsNullOrEmpty($githubSha) -and $githubSha.Length -ge 7) {
+  $commit = $githubSha.Substring(0, 7)
+}
+$effectiveVersion = "${env:VERSION}"
+if ([string]::IsNullOrWhiteSpace($effectiveVersion)) {
+  $effectiveVersion = "v0.0.0-dev"
+}
+$base = "qrrun_${effectiveVersion}_windows_${env:GOARCH}"
 
 New-Item -ItemType Directory -Path dist -Force | Out-Null
 
 $env:CGO_ENABLED = "0"
 $env:GOOS = "windows"
-go build -trimpath -ldflags "-s -w -X 'main.version=${env:VERSION}' -X 'main.commit=${commit}' -X 'main.date=${date}'" -o "dist/${base}.exe" ./cmd/qrrun
+go build -trimpath -ldflags "-s -w -X 'main.version=${effectiveVersion}' -X 'main.commit=${commit}' -X 'main.date=${date}'" -o "dist/${base}.exe" ./cmd/qrrun
 
-$match = [regex]::Match($env:VERSION, '^[vV]?(\d+)\.(\d+)\.(\d+)(?:-[A-Za-z]+\.(\d+))?')
+$match = [regex]::Match($effectiveVersion, '^[vV]?(\d+)\.(\d+)\.(\d+)(?:-[A-Za-z]+\.(\d+))?')
 if (-not $match.Success) {
-  throw "Tag '$env:VERSION' must start with SemVer core (e.g. v1.2.3) for MSI versioning"
+  throw "Tag '${effectiveVersion}' must start with SemVer core (e.g. v1.2.3) for MSI versioning"
 }
 
 $major = [int]$match.Groups[1].Value


### PR DESCRIPTION
## Summary
- tighten PowerShell static analysis in pre-commit by failing on Information severity too
- harden windows MSI release script environment handling for missing `GITHUB_SHA`/`VERSION`

## Changes
- update `scripts/precommit_psscriptanalyzer.ps1`
  - run `Invoke-ScriptAnalyzer` with `Error, Warning, Information`
- update `scripts/release_build_windows_msi.ps1`
  - guard short/empty `GITHUB_SHA`
  - default empty `VERSION` to `v0.0.0-dev`
  - use `effectiveVersion` consistently in ldflags and semver parsing

## Validation
- `pre-commit run psscriptanalyzer --all-files --verbose`
