### PR TITLE
Support script args and minify Pythonista exec code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ See [Cloudflare Quick Tunnel documentation](https://developers.cloudflare.com/cl
 Run with a local file:
 
 ```bash
-qrrun hello.py
+qrrun hello.py arg1 arg2
 ```
 
 Run from stdin (`-`):
 
 ```bash
-echo "print('Hello, QRrun!')" | qrrun -
+echo "print('Hello, QRrun!')" | qrrun - arg1 arg2
 ```
 
 By default, QRrun generates a QR code for opening and running your script in Pythonista3 via Cloudflare Quick Tunnels, unless you explicitly override `--transport` or `--runtime`.

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -3,8 +3,8 @@
 //
 // Usage:
 //
-//	qrrun your-local-script.py
-//	echo "print('hello')" | qrrun -
+//	qrrun your-local-script.py arg1 arg2
+//	echo "print('hello')" | qrrun - arg1 arg2
 package main
 
 import (
@@ -43,7 +43,7 @@ func newRootCmd() *cobra.Command {
 	var transportOpts string
 
 	cmd := &cobra.Command{
-		Use:   "qrrun [flags] <script|-]",
+		Use:   "qrrun [flags] <script|-> [args...]",
 		Short: "tunnel local scripts and run via QR",
 		Long: `QRrun serves a local script through a secure tunnel and prints a QR code.
 
@@ -54,15 +54,18 @@ Prerequisites:
 	QRrun uses Cloudflare Quick Tunnels (trycloudflare.com)
 
 Examples:
-	qrrun hello.py
-	echo "print('hello')" | qrrun -`,
-		Args: cobra.ExactArgs(1),
+	qrrun hello.py arg1 arg2
+	echo "print('hello')" | qrrun - arg1 arg2`,
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			keepServingMode := keepServing
+			scriptPath := args[0]
+			scriptArgs := append([]string(nil), args[1:]...)
 			return app.Run(app.Options{
 				TransportName:   transportName,
 				RuntimeName:     runtimeName,
-				ScriptPath:      args[0],
+				ScriptPath:      scriptPath,
+				ScriptArgs:      scriptArgs,
 				KeepServing:     keepServingMode,
 				ExitQuietPeriod: exitQuietPeriod,
 				Debug:           debug,

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,6 +27,7 @@ type Options struct {
 	TransportName   string
 	RuntimeName     string
 	ScriptPath      string
+	ScriptArgs      []string
 	KeepServing     bool
 	ExitQuietPeriod time.Duration
 	Debug           bool
@@ -154,7 +155,14 @@ func Run(opts Options) error {
 
 	// Build the QR code URL: replace the local base URL with the public one,
 	// then let the runtime wrap it in the appropriate URL scheme.
-	scriptPublicURL := rt.QRCodeURL(replaceBase(srv.ScriptURL(), publicURL), bearerToken)
+	scriptArgv := make([]string, 0, 1+len(opts.ScriptArgs))
+	scriptArgv = append(scriptArgv, opts.ScriptPath)
+	scriptArgv = append(scriptArgv, opts.ScriptArgs...)
+	scriptPublicURL := rt.QRCodeURL(
+		replaceBase(srv.ScriptURL(), publicURL),
+		bearerToken,
+		scriptArgv,
+	)
 
 	if opts.PrintURL {
 		fmt.Fprintln(opts.Output, scriptPublicURL)

--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -13,8 +13,28 @@ type Pythonista struct {
 }
 
 // QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
-func (p *Pythonista) QRCodeURL(publicURL string, bearerToken string) string {
-	code := fmt.Sprintf("import urllib.request as u;exec(u.urlopen(u.Request(%q,headers={\"Authorization\":\"Bearer %s\"})).read().decode())", publicURL, bearerToken)
+func (p *Pythonista) QRCodeURL(publicURL string, bearerToken string, scriptArgv []string) string {
+	argvLiteral := pythonStringListLiteral(scriptArgv)
+	code := fmt.Sprintf(
+		"import sys,urllib.request as u;a=sys.argv[:];sys.argv=%s\n"+
+			"try:eval(compile(u.urlopen(u.Request(%q,headers={\"Authorization\":\"Bearer %s\"})).read().decode(),\"<qrrun>\",\"exec\"),{\"__name__\":\"__main__\"})\n"+
+			"finally:sys.argv=a",
+		argvLiteral,
+		publicURL,
+		bearerToken,
+	)
 	encoded := strings.ReplaceAll(url.QueryEscape(code), "+", " ")
 	return fmt.Sprintf("%s://?exec=%s", p.Scheme, encoded)
+}
+
+func pythonStringListLiteral(values []string) string {
+	if len(values) == 0 {
+		return "[]"
+	}
+
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", value))
+	}
+	return "[" + strings.Join(quoted, ",") + "]"
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -13,7 +13,7 @@ import (
 type Runtime interface {
 	// QRCodeURL returns the URL to encode in the QR code given the public URL
 	// of the script.
-	QRCodeURL(publicURL string, bearerToken string) string
+	QRCodeURL(publicURL string, bearerToken string, scriptArgv []string) string
 }
 
 // New returns a Runtime for the given name or an error when the name is

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -40,6 +40,7 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 
 	rawURL := "https://example.trycloudflare.com/hello.py"
 	bearerToken := "test-token-123"
+	scriptArgv := []string{"hello.py", "arg1", "arg2"}
 
 	for _, tc := range tests {
 		rt, err := runtime.New(tc.name)
@@ -47,7 +48,7 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 			t.Fatalf("unexpected error for %q: %v", tc.name, err)
 		}
 
-		got := rt.QRCodeURL(rawURL, bearerToken)
+		got := rt.QRCodeURL(rawURL, bearerToken, scriptArgv)
 		if !strings.HasPrefix(got, tc.scheme+"://") {
 			t.Errorf("expected %s:// scheme, got %q", tc.scheme, got)
 		}
@@ -68,14 +69,20 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to decode exec code for %q: %v (raw: %q)", tc.name, err, rawExec)
 		}
-		if !strings.HasPrefix(execCode, "import urllib.request as u;exec(") {
-			t.Errorf("expected urllib.request-based exec code prefix for %q, got %q", tc.name, execCode)
+		if !strings.Contains(execCode, "a=sys.argv[:]") {
+			t.Errorf("expected sys.argv backup in exec code for %q, got %q", tc.name, execCode)
 		}
-		if !strings.Contains(execCode, "u.urlopen(u.Request(") {
-			t.Errorf("expected urllib.request urlopen/request usage in exec code for %q, got %q", tc.name, execCode)
+		if !strings.Contains(execCode, "sys.argv=[\"hello.py\",\"arg1\",\"arg2\"]") {
+			t.Errorf("expected script argv overwrite in exec code for %q, got %q", tc.name, execCode)
 		}
-		if !strings.Contains(execCode, ".read().decode())") {
-			t.Errorf("expected decoded response execution suffix in exec code for %q, got %q", tc.name, execCode)
+		if !strings.Contains(execCode, "eval(") || !strings.Contains(execCode, "compile(") || !strings.Contains(execCode, "u.urlopen(u.Request(") {
+			t.Errorf("expected eval(compile(u.urlopen(u.Request(...)))) in exec code for %q, got %q", tc.name, execCode)
+		}
+		if !strings.Contains(execCode, "finally:") || !strings.Contains(execCode, "sys.argv=a") {
+			t.Errorf("expected sys.argv restore in finally for %q, got %q", tc.name, execCode)
+		}
+		if !strings.Contains(execCode, "import sys,urllib.request as u") {
+			t.Errorf("expected urllib import in exec code for %q, got %q", tc.name, execCode)
 		}
 		if !strings.Contains(execCode, "Authorization") {
 			t.Errorf("expected Authorization header in exec code for %q, got %q", tc.name, execCode)


### PR DESCRIPTION
## Summary
- support passing script arguments from CLI to runtime-generated Python exec code
- preserve and restore sys.argv in Pythonista execution code via try/finally
- minify embedded Python code passed in the QR URL
- update runtime tests to match the minified/generated code behavior

## Validation
- go test ./...
