### PR TITLE
Reduce QR payload and harden auth failure handling

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,7 +5,6 @@ package app
 import (
 	"context"
 	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net/url"
@@ -40,6 +39,8 @@ type Options struct {
 }
 
 const DefaultExitQuietPeriod = 500 * time.Millisecond
+
+const alphaNumChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 // Run performs the full QRrun workflow:
 //  1. Validates options and resolves the transport / runtime.
@@ -158,8 +159,9 @@ func Run(opts Options) error {
 	scriptArgv := make([]string, 0, 1+len(opts.ScriptArgs))
 	scriptArgv = append(scriptArgv, opts.ScriptPath)
 	scriptArgv = append(scriptArgv, opts.ScriptArgs...)
+	scriptURLWithToken := withQueryToken(replaceBase(srv.ScriptURL(), publicURL), bearerToken)
 	scriptPublicURL := rt.QRCodeURL(
-		replaceBase(srv.ScriptURL(), publicURL),
+		scriptURLWithToken,
 		bearerToken,
 		scriptArgv,
 	)
@@ -249,11 +251,42 @@ func Run(opts Options) error {
 }
 
 func generateBearerToken() (string, error) {
-	raw := make([]byte, 24)
-	if _, err := rand.Read(raw); err != nil {
-		return "", err
+	b := make([]byte, 8)
+	for i := range b {
+		idx, err := randomAlphaNumIndex(len(alphaNumChars))
+		if err != nil {
+			return "", err
+		}
+		b[i] = alphaNumChars[idx]
 	}
-	return hex.EncodeToString(raw), nil
+	return string(b), nil
+}
+
+func randomAlphaNumIndex(max int) (int, error) {
+	if max <= 0 || max > 256 {
+		return 0, fmt.Errorf("invalid max: %d", max)
+	}
+	limit := byte(256 - (256 % max))
+	for {
+		var one [1]byte
+		if _, err := rand.Read(one[:]); err != nil {
+			return 0, err
+		}
+		if one[0] < limit {
+			return int(one[0]) % max, nil
+		}
+	}
+}
+
+func withQueryToken(rawURL, token string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := parsed.Query()
+	q.Set("t", token)
+	parsed.RawQuery = q.Encode()
+	return parsed.String()
 }
 
 func loadScriptContent(scriptPath string, input io.Reader) ([]byte, error) {

--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -13,15 +13,14 @@ type Pythonista struct {
 }
 
 // QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
-func (p *Pythonista) QRCodeURL(publicURL string, bearerToken string, scriptArgv []string) string {
+func (p *Pythonista) QRCodeURL(publicURL string, _ string, scriptArgv []string) string {
 	argvLiteral := pythonStringListLiteral(scriptArgv)
 	code := fmt.Sprintf(
 		"import sys,urllib.request as u;a=sys.argv[:];sys.argv=%s\n"+
-			"try:eval(compile(u.urlopen(u.Request(%q,headers={\"Authorization\":\"Bearer %s\"})).read().decode(),\"<qrrun>\",\"exec\"),{\"__name__\":\"__main__\"})\n"+
+			"try:exec(u.urlopen(%q).read().decode(),{\"__name__\":\"__main__\"})\n"+
 			"finally:sys.argv=a",
 		argvLiteral,
 		publicURL,
-		bearerToken,
 	)
 	encoded := strings.ReplaceAll(url.QueryEscape(code), "+", " ")
 	return fmt.Sprintf("%s://?exec=%s", p.Scheme, encoded)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -75,8 +75,8 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		if !strings.Contains(execCode, "sys.argv=[\"hello.py\",\"arg1\",\"arg2\"]") {
 			t.Errorf("expected script argv overwrite in exec code for %q, got %q", tc.name, execCode)
 		}
-		if !strings.Contains(execCode, "eval(") || !strings.Contains(execCode, "compile(") || !strings.Contains(execCode, "u.urlopen(u.Request(") {
-			t.Errorf("expected eval(compile(u.urlopen(u.Request(...)))) in exec code for %q, got %q", tc.name, execCode)
+		if !strings.Contains(execCode, "exec(u.urlopen(") {
+			t.Errorf("expected exec(u.urlopen(...)) in exec code for %q, got %q", tc.name, execCode)
 		}
 		if !strings.Contains(execCode, "finally:") || !strings.Contains(execCode, "sys.argv=a") {
 			t.Errorf("expected sys.argv restore in finally for %q, got %q", tc.name, execCode)
@@ -84,14 +84,8 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		if !strings.Contains(execCode, "import sys,urllib.request as u") {
 			t.Errorf("expected urllib import in exec code for %q, got %q", tc.name, execCode)
 		}
-		if !strings.Contains(execCode, "Authorization") {
-			t.Errorf("expected Authorization header in exec code for %q, got %q", tc.name, execCode)
-		}
 		if strings.Contains(execCode, "requests") {
 			t.Errorf("did not expect requests dependency in exec code for %q, got %q", tc.name, execCode)
-		}
-		if !strings.Contains(execCode, "Bearer "+bearerToken) {
-			t.Errorf("expected Bearer token in exec code for %q, got %q", tc.name, execCode)
 		}
 		if !strings.Contains(execCode, rawURL) {
 			t.Errorf("expected raw URL in exec code for %q, got %q", tc.name, execCode)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -40,6 +39,8 @@ type Server struct {
 	deliveryCh  chan struct{}
 	firstReq    sync.Once
 }
+
+const alphaNumChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 // New creates a Server that serves scriptBytes on a random free port.
 // The script is exposed at /<uuid-without-extension>.
@@ -122,7 +123,9 @@ func (s *Server) Serve(ctx context.Context) error {
 	mux.HandleFunc("/"+s.scriptID, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(s.requestLog, "request: method=%s path=%s remote=%s\n", r.Method, r.URL.Path, r.RemoteAddr)
 		auth := strings.TrimSpace(r.Header.Get("Authorization"))
-		if auth != "Bearer "+s.bearerToken {
+		queryToken := strings.TrimSpace(r.URL.Query().Get("t"))
+		if auth != "Bearer "+s.bearerToken && queryToken != s.bearerToken {
+			time.Sleep(1 * time.Second)
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -171,12 +174,31 @@ func (s *Server) Serve(ctx context.Context) error {
 	}
 }
 func newScriptID() (string, error) {
-	raw := make([]byte, 16)
-	if _, err := rand.Read(raw); err != nil {
-		return "", err
+	b := make([]byte, 8)
+	for i := range b {
+		idx, err := randomAlphaNumIndex(len(alphaNumChars))
+		if err != nil {
+			return "", err
+		}
+		b[i] = alphaNumChars[idx]
 	}
-	// 32 hex chars, extensionless UUID-like identifier suitable for URL path.
-	return hex.EncodeToString(raw), nil
+	return string(b), nil
+}
+
+func randomAlphaNumIndex(max int) (int, error) {
+	if max <= 0 || max > 256 {
+		return 0, fmt.Errorf("invalid max: %d", max)
+	}
+	limit := byte(256 - (256 % max))
+	for {
+		var one [1]byte
+		if _, err := rand.Read(one[:]); err != nil {
+			return 0, err
+		}
+		if one[0] < limit {
+			return int(one[0]) % max, nil
+		}
+	}
 }
 
 type originTLSArtifacts struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"testing"
@@ -82,8 +83,8 @@ func TestServer_URLFormat(t *testing.T) {
 	if strings.Contains(id, ".") {
 		t.Errorf("expected extensionless script id, got %q", id)
 	}
-	if ok, _ := regexp.MatchString("^[a-f0-9]{32}$", id); !ok {
-		t.Errorf("expected 32-char lowercase hex script id, got %q", id)
+	if ok, _ := regexp.MatchString("^[a-zA-Z0-9]{8}$", id); !ok {
+		t.Errorf("expected 8-char alnum script id, got %q", id)
 	}
 }
 
@@ -223,11 +224,15 @@ func TestServer_RejectsUnauthorizedRequest(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
+	start := time.Now()
 	resp, err := doRequest(serverHTTPClient(srv), http.MethodGet, srv.ScriptURL(), "wrong-token", nil)
 	if err != nil {
 		t.Fatalf("GET %s: %v", srv.ScriptURL(), err)
 	}
 	defer resp.Body.Close()
+	if elapsed := time.Since(start); elapsed < 950*time.Millisecond {
+		t.Fatalf("expected unauthorized response delay around 1s, got %s", elapsed)
+	}
 
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401 Unauthorized, got %d", resp.StatusCode)
@@ -240,12 +245,45 @@ func TestServer_RejectsUnauthorizedRequest(t *testing.T) {
 	}
 }
 
+func TestServer_AcceptsQueryToken(t *testing.T) {
+	srv, err := server.New([]byte("print('ok')\n"), "text/x-python; charset=utf-8", testBearerToken, io.Discard)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = srv.Serve(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	queryURL := srv.ScriptURL() + "?t=" + url.QueryEscape(testBearerToken)
+	resp, err := doRequestRawURL(serverHTTPClient(srv), http.MethodGet, queryURL, "", nil)
+	if err != nil {
+		t.Fatalf("GET %s: %v", queryURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+	}
+}
+
 func doRequest(client *http.Client, method, url, bearerToken string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(method, url, body)
+	return doRequestRawURL(client, method, url, bearerToken, body)
+}
+
+func doRequestRawURL(client *http.Client, method, rawURL, bearerToken string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, rawURL, body)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	if bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+	}
 	return client.Do(req)
 }
 


### PR DESCRIPTION
## Summary
- reduce QR payload size by shortening script IDs and auth token to 8-char alnum values
- switch Pythonista fetch path to use query token (`t`) and further minify embedded exec code
- add a 1-second response delay on token auth failures to raise brute-force cost
- update runtime/server tests for new payload/auth behavior

## Validation
- go test ./...
