### PR TITLE
Add configurable QR error correction level

### DIFF
--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -34,6 +34,7 @@ func main() {
 func newRootCmd() *cobra.Command {
 	var transportName string
 	var runtimeName string
+	var qrLevel string
 	var keepServing bool
 	var exitQuietPeriod time.Duration
 	var transportStderr bool
@@ -64,6 +65,7 @@ Examples:
 			return app.Run(app.Options{
 				TransportName:   transportName,
 				RuntimeName:     runtimeName,
+				QRErrorLevel:    qrLevel,
 				ScriptPath:      scriptPath,
 				ScriptArgs:      scriptArgs,
 				KeepServing:     keepServingMode,
@@ -87,6 +89,8 @@ Examples:
 		`quiet period before exit`)
 	cmd.Flags().StringVar(&runtimeName, "runtime", "pythonista3",
 		`target runtime`)
+	cmd.Flags().StringVar(&qrLevel, "qr-level", "M",
+		`QR error correction level: L, M, Q, or H`)
 	cmd.Flags().StringVar(&transportName, "transport", "cloudflared",
 		`tunnel transport`)
 	cmd.Flags().StringVar(&transportOpts, "transport-opts", "",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,6 +25,7 @@ import (
 type Options struct {
 	TransportName   string
 	RuntimeName     string
+	QRErrorLevel    string
 	ScriptPath      string
 	ScriptArgs      []string
 	KeepServing     bool
@@ -54,6 +55,10 @@ func Run(opts Options) error {
 	}
 	if opts.Output == nil {
 		opts.Output = os.Stdout
+	}
+	qrLevel, err := parseQRErrorLevel(opts.QRErrorLevel)
+	if err != nil {
+		return err
 	}
 	statusOutput := io.Writer(os.Stderr)
 	quietPeriod := opts.ExitQuietPeriod
@@ -169,7 +174,7 @@ func Run(opts Options) error {
 	if opts.PrintURL {
 		fmt.Fprintln(opts.Output, scriptPublicURL)
 	} else {
-		if err := renderCompactQRCode(opts.Output, scriptPublicURL); err != nil {
+		if err := renderCompactQRCode(opts.Output, scriptPublicURL, qrLevel); err != nil {
 			return fmt.Errorf("render qr: %w", err)
 		}
 		if opts.KeepServing {
@@ -320,8 +325,23 @@ func replaceBase(rawURL, publicBase string) string {
 	return rawParsed.String()
 }
 
-func renderCompactQRCode(w io.Writer, content string) error {
-	code, err := qr.Encode(content, qr.M)
+func parseQRErrorLevel(level string) (qr.Level, error) {
+	switch strings.ToUpper(strings.TrimSpace(level)) {
+	case "", "M":
+		return qr.M, nil
+	case "L":
+		return qr.L, nil
+	case "Q":
+		return qr.Q, nil
+	case "H":
+		return qr.H, nil
+	default:
+		return 0, fmt.Errorf("invalid qr level %q: must be one of L, M, Q, H", level)
+	}
+}
+
+func renderCompactQRCode(w io.Writer, content string, level qr.Level) error {
+	code, err := qr.Encode(content, level)
 	if err != nil {
 		return err
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,6 +2,7 @@ package app_test
 
 import (
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/sakurai-youhei/qrrun/internal/app"
@@ -41,5 +42,17 @@ func TestRun_InvalidScriptPath(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for invalid script path")
+	}
+}
+
+func TestRun_InvalidQRErrorLevel(t *testing.T) {
+	err := app.Run(app.Options{
+		QRErrorLevel: "X",
+		ScriptPath:   "-",
+		Input:        strings.NewReader("print('ok')\n"),
+		Output:       io.Discard,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid qr level")
 	}
 }


### PR DESCRIPTION
## Summary
- add --qr-level option to choose QR error correction level (L/M/Q/H)
- keep M as the default level for backward compatibility
- validate invalid levels early and return clear error
- add app test for invalid QR level

## Validation
- go test ./...
