### PR TITLE
Extend Pythonista runtime support and refine help output

### DIFF
--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -82,6 +82,18 @@ Examples:
 
 	cmd.Version = fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date)
 	cmd.SetVersionTemplate("{{.Version}}\n")
+	cmd.SetUsageTemplate(`Usage:
+  {{.UseLine}}
+
+{{if .HasAvailableFlags}}Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
+
+Supported QR error correction levels:
+	` + app.SupportedQRErrorLevelsText() + `
+
+Supported runtimes:
+	pythonista, pythonista2, pythonista3
+{{end}}`)
 
 	cmd.Flags().BoolVar(&keepServing, "keep-serving", false,
 		`keep serving requests until interrupted`)
@@ -89,8 +101,8 @@ Examples:
 		`quiet period before exit`)
 	cmd.Flags().StringVar(&runtimeName, "runtime", "pythonista3",
 		`target runtime`)
-	cmd.Flags().StringVar(&qrLevel, "qr-level", "M",
-		`QR error correction level: L, M, Q, or H`)
+	cmd.Flags().StringVar(&qrLevel, "qr-level", app.DefaultQRErrorLevel,
+		`QR error correction level`)
 	cmd.Flags().StringVar(&transportName, "transport", "cloudflared",
 		`tunnel transport`)
 	cmd.Flags().StringVar(&transportOpts, "transport-opts", "",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -43,6 +43,21 @@ const DefaultExitQuietPeriod = 500 * time.Millisecond
 
 const alphaNumChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
+const DefaultQRErrorLevel = "M"
+
+var SupportedQRErrorLevels = []string{"L", "M", "Q", "H"}
+
+var qrLevelByName = map[string]qr.Level{
+	"L": qr.L,
+	"M": qr.M,
+	"Q": qr.Q,
+	"H": qr.H,
+}
+
+func SupportedQRErrorLevelsText() string {
+	return strings.Join(SupportedQRErrorLevels, ", ")
+}
+
 // Run performs the full QRrun workflow:
 //  1. Validates options and resolves the transport / runtime.
 //  2. Starts a local HTTP server to serve the script.
@@ -326,18 +341,14 @@ func replaceBase(rawURL, publicBase string) string {
 }
 
 func parseQRErrorLevel(level string) (qr.Level, error) {
-	switch strings.ToUpper(strings.TrimSpace(level)) {
-	case "", "M":
-		return qr.M, nil
-	case "L":
-		return qr.L, nil
-	case "Q":
-		return qr.Q, nil
-	case "H":
-		return qr.H, nil
-	default:
-		return 0, fmt.Errorf("invalid qr level %q: must be one of L, M, Q, H", level)
+	normalized := strings.ToUpper(strings.TrimSpace(level))
+	if normalized == "" {
+		normalized = DefaultQRErrorLevel
 	}
+	if mapped, ok := qrLevelByName[normalized]; ok {
+		return mapped, nil
+	}
+	return 0, fmt.Errorf("invalid qr level %q: must be one of %s", level, SupportedQRErrorLevelsText())
 }
 
 func renderCompactQRCode(w io.Writer, content string, level qr.Level) error {

--- a/internal/runtime/pythonista3.go
+++ b/internal/runtime/pythonista3.go
@@ -9,21 +9,39 @@ import (
 // Pythonista produces URLs for Pythonista runtimes.
 // It embeds Python code via the `exec` URL parameter.
 type Pythonista struct {
-	Scheme string
+	Scheme  string
+	Python2 bool
 }
 
-// QRCodeURL converts a raw script URL into a Pythonista 3 deep-link URL.
+// QRCodeURL converts a raw script URL into a Pythonista deep-link URL.
 func (p *Pythonista) QRCodeURL(publicURL string, _ string, scriptArgv []string) string {
 	argvLiteral := pythonStringListLiteral(scriptArgv)
-	code := fmt.Sprintf(
+	code := pythonista3ExecCode(publicURL, argvLiteral)
+	if p.Python2 {
+		code = pythonista2ExecCode(publicURL, argvLiteral)
+	}
+	encoded := strings.ReplaceAll(url.QueryEscape(code), "+", " ")
+	return fmt.Sprintf("%s://?exec=%s", p.Scheme, encoded)
+}
+
+func pythonista3ExecCode(publicURL, argvLiteral string) string {
+	return fmt.Sprintf(
 		"import sys,urllib.request as u;a=sys.argv[:];sys.argv=%s\n"+
 			"try:exec(u.urlopen(%q).read().decode(),{\"__name__\":\"__main__\"})\n"+
 			"finally:sys.argv=a",
 		argvLiteral,
 		publicURL,
 	)
-	encoded := strings.ReplaceAll(url.QueryEscape(code), "+", " ")
-	return fmt.Sprintf("%s://?exec=%s", p.Scheme, encoded)
+}
+
+func pythonista2ExecCode(publicURL, argvLiteral string) string {
+	return fmt.Sprintf(
+		"import sys,urllib2 as u;a=sys.argv[:];sys.argv=%s\n"+
+			"try:exec u.urlopen(%q).read() in {\"__name__\":\"__main__\"}\n"+
+			"finally:sys.argv=a",
+		argvLiteral,
+		publicURL,
+	)
 }
 
 func pythonStringListLiteral(values []string) string {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -21,11 +21,11 @@ type Runtime interface {
 func New(name string) (Runtime, error) {
 	switch name {
 	case "pythonista":
-		return &Pythonista{Scheme: "pythonista"}, nil
+		return &Pythonista{Scheme: "pythonista", Python2: false}, nil
 	case "pythonista2":
-		return &Pythonista{Scheme: "pythonista2"}, nil
+		return &Pythonista{Scheme: "pythonista2", Python2: true}, nil
 	case "pythonista3":
-		return &Pythonista{Scheme: "pythonista3"}, nil
+		return &Pythonista{Scheme: "pythonista3", Python2: false}, nil
 	default:
 		return nil, fmt.Errorf("unknown runtime %q (available: pythonista, pythonista2, pythonista3)", name)
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -30,12 +30,13 @@ func TestNew_UnknownRuntime(t *testing.T) {
 
 func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 	tests := []struct {
-		name   string
-		scheme string
+		name      string
+		scheme    string
+		isPython2 bool
 	}{
-		{name: "pythonista", scheme: "pythonista"},
-		{name: "pythonista2", scheme: "pythonista2"},
-		{name: "pythonista3", scheme: "pythonista3"},
+		{name: "pythonista", scheme: "pythonista", isPython2: false},
+		{name: "pythonista2", scheme: "pythonista2", isPython2: true},
+		{name: "pythonista3", scheme: "pythonista3", isPython2: false},
 	}
 
 	rawURL := "https://example.trycloudflare.com/hello.py"
@@ -75,14 +76,26 @@ func TestPythonista_QRCodeURL_ExecScheme(t *testing.T) {
 		if !strings.Contains(execCode, "sys.argv=[\"hello.py\",\"arg1\",\"arg2\"]") {
 			t.Errorf("expected script argv overwrite in exec code for %q, got %q", tc.name, execCode)
 		}
-		if !strings.Contains(execCode, "exec(u.urlopen(") {
-			t.Errorf("expected exec(u.urlopen(...)) in exec code for %q, got %q", tc.name, execCode)
+		if tc.isPython2 {
+			if !strings.Contains(execCode, "import sys,urllib2 as u") {
+				t.Errorf("expected urllib2 import in exec code for %q, got %q", tc.name, execCode)
+			}
+			if !strings.Contains(execCode, "exec u.urlopen(") || !strings.Contains(execCode, ").read() in {") {
+				t.Errorf("expected Python2 exec statement in exec code for %q, got %q", tc.name, execCode)
+			}
+			if strings.Contains(execCode, ".decode()") {
+				t.Errorf("did not expect decode() in python2 exec code for %q, got %q", tc.name, execCode)
+			}
+		} else {
+			if !strings.Contains(execCode, "import sys,urllib.request as u") {
+				t.Errorf("expected urllib.request import in exec code for %q, got %q", tc.name, execCode)
+			}
+			if !strings.Contains(execCode, "exec(u.urlopen(") || !strings.Contains(execCode, ".read().decode()") {
+				t.Errorf("expected Python3 exec(u.urlopen(...).read().decode()) in exec code for %q, got %q", tc.name, execCode)
+			}
 		}
 		if !strings.Contains(execCode, "finally:") || !strings.Contains(execCode, "sys.argv=a") {
 			t.Errorf("expected sys.argv restore in finally for %q, got %q", tc.name, execCode)
-		}
-		if !strings.Contains(execCode, "import sys,urllib.request as u") {
-			t.Errorf("expected urllib import in exec code for %q, got %q", tc.name, execCode)
 		}
 		if strings.Contains(execCode, "requests") {
 			t.Errorf("did not expect requests dependency in exec code for %q, got %q", tc.name, execCode)


### PR DESCRIPTION
## Summary
- add explicit runtime behavior split for pythonista/pythonista2/pythonista3 (pythonista2 uses Python2 payload)
- improve qrrun help layout and add supported runtime/QR-level sections after flags
- externalize supported QR error correction level definitions and reuse for parsing/help

## Validation
- go test ./...
