### PR TITLE
Add cross-platform CI E2E checks with cloudflared

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,20 +114,15 @@ jobs:
           winget install --id Cloudflare.cloudflared --exact --silent --accept-package-agreements --accept-source-agreements
 
           $candidates = @(
-            "$env:ProgramFiles\\cloudflared\\cloudflared.exe",
-            "$env:ProgramFiles\\Cloudflared\\cloudflared.exe",
-            "$env:ProgramFiles\\Cloudflare\\Cloudflared\\cloudflared.exe",
-            "$env:ProgramFiles(x86)\\cloudflared\\cloudflared.exe",
-            "$env:ProgramFiles(x86)\\Cloudflared\\cloudflared.exe",
-            "$env:ProgramFiles(x86)\\Cloudflare\\Cloudflared\\cloudflared.exe"
+            "${env:ProgramFiles}\\cloudflared\\cloudflared.exe",
+            "${env:ProgramFiles}\\Cloudflared\\cloudflared.exe",
+            "${env:ProgramFiles}\\Cloudflare\\Cloudflared\\cloudflared.exe",
+            "${env:ProgramFiles(x86)}\\cloudflared\\cloudflared.exe",
+            "${env:ProgramFiles(x86)}\\Cloudflared\\cloudflared.exe",
+            "${env:ProgramFiles(x86)}\\Cloudflare\\Cloudflared\\cloudflared.exe"
           )
 
           $exe = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if (-not $exe) {
-            $exe = Get-ChildItem "$env:ProgramFiles", "$env:ProgramFiles(x86)" -Filter cloudflared.exe -Recurse -ErrorAction SilentlyContinue |
-              Select-Object -ExpandProperty FullName -First 1
-          }
-
           if (-not $exe) {
             throw "cloudflared.exe was installed but could not be located"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,28 @@ jobs:
         shell: pwsh
         run: |
           winget install --id Cloudflare.cloudflared --exact --silent --accept-package-agreements --accept-source-agreements
-          cloudflared --version
+
+          $candidates = @(
+            "$env:ProgramFiles\\cloudflared\\cloudflared.exe",
+            "$env:ProgramFiles\\Cloudflared\\cloudflared.exe",
+            "$env:ProgramFiles\\Cloudflare\\Cloudflared\\cloudflared.exe",
+            "$env:ProgramFiles(x86)\\cloudflared\\cloudflared.exe",
+            "$env:ProgramFiles(x86)\\Cloudflared\\cloudflared.exe",
+            "$env:ProgramFiles(x86)\\Cloudflare\\Cloudflared\\cloudflared.exe"
+          )
+
+          $exe = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $exe) {
+            $exe = Get-ChildItem "$env:ProgramFiles", "$env:ProgramFiles(x86)" -Filter cloudflared.exe -Recurse -ErrorAction SilentlyContinue |
+              Select-Object -ExpandProperty FullName -First 1
+          }
+
+          if (-not $exe) {
+            throw "cloudflared.exe was installed but could not be located"
+          }
+
+          (Split-Path -Parent $exe) | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & $exe --version
 
       - name: Run E2E test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,29 @@ jobs:
             go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...
           fi
 
+  checks-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run checks
+        shell: bash
+        run: |
+          go test ./...
+          go vet ./...
+          go build ./...
+          if command -v golangci-lint >/dev/null 2>&1; then
+            golangci-lint run ./...
+          else
+            go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...
+          fi
+
   e2e-linux:
     runs-on: ubuntu-latest
     steps:
@@ -62,29 +85,6 @@ jobs:
         shell: bash
         run: |
           make test-e2e
-
-  checks-windows:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Run checks
-        shell: bash
-        run: |
-          go test ./...
-          go vet ./...
-          go build ./...
-          if command -v golangci-lint >/dev/null 2>&1; then
-            golangci-lint run ./...
-          else
-            go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...
-          fi
 
   e2e-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,36 @@ jobs:
             go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...
           fi
 
+  e2e-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install cloudflared
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL -o cloudflared.deb \
+            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+          sudo dpkg -i cloudflared.deb
+          cloudflared --version
+
+      - name: Run E2E test
+        shell: bash
+        run: |
+          make test-e2e
+
   checks-windows:
     runs-on: windows-latest
     steps:
@@ -55,3 +85,36 @@ jobs:
           else
             go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run ./...
           fi
+
+  e2e-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Setup make
+        shell: pwsh
+        run: |
+          choco install make -y
+          make --version
+
+      - name: Install cloudflared
+        shell: pwsh
+        run: |
+          winget install --id Cloudflare.cloudflared --exact --silent --accept-package-agreements --accept-source-agreements
+          cloudflared --version
+
+      - name: Run E2E test
+        shell: bash
+        run: |
+          make test-e2e

--- a/scripts/e2e_print_url.py
+++ b/scripts/e2e_print_url.py
@@ -5,6 +5,7 @@ import secrets
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import unittest
@@ -73,11 +74,16 @@ class TestE2EPrintURL(unittest.TestCase):
         )
 
     def test_validate_url_roundtrip(self) -> None:
+        qrrun_stderr = tempfile.TemporaryFile(mode="w+t")
+        self.addCleanup(qrrun_stderr.close)
+
         qrrun = subprocess.Popen(
             [
                 self.qrrun_bin,
                 "--transport",
                 "cloudflared",
+                "--transport-stderr",
+                "--debug",
                 "--runtime",
                 "pythonista3",
                 "--print-url",
@@ -85,7 +91,7 @@ class TestE2EPrintURL(unittest.TestCase):
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=qrrun_stderr,
             text=True,
         )
         self.addCleanup(terminate_proc_gracefully, qrrun)
@@ -99,9 +105,20 @@ class TestE2EPrintURL(unittest.TestCase):
         qrrun.stdin.write(self.script)
         qrrun.stdin.close()
 
-        url_line = readline(qrrun.stdout, timeout=30.0).strip()
+        try:
+            url_line = readline(qrrun.stdout, timeout=30.0).strip()
+        except TimeoutError as exc:
+            qrrun_stderr.seek(0)
+            stderr_text = qrrun_stderr.read().strip()
+            self.fail(f"{exc}; qrrun stderr: {stderr_text!r}")
+
         if not url_line:
-            self.fail("qrrun outputs a valid URL")
+            qrrun_stderr.seek(0)
+            stderr_text = qrrun_stderr.read().strip()
+            self.fail(
+                "qrrun does not output a valid URL; "
+                f"qrrun stderr: {stderr_text!r}"
+            )
 
         self.assertRegex(
             url_line,

--- a/scripts/e2e_print_url.py
+++ b/scripts/e2e_print_url.py
@@ -157,8 +157,8 @@ class TestE2EPrintURL(unittest.TestCase):
 
         transferred = python.stderr
         self.assertEqual(
-            transferred,
-            self.script,
+            transferred.rstrip("\n"),
+            self.script.rstrip("\n"),
             f"script mismatch: expected {self.script!r}, got {transferred!r}",
         )
 

--- a/scripts/e2e_print_url.py
+++ b/scripts/e2e_print_url.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import secrets
 import select
 import shutil
@@ -6,6 +7,8 @@ import subprocess
 import sys
 import time
 import unittest
+from functools import cached_property
+from textwrap import dedent
 from urllib.parse import unquote
 
 
@@ -22,12 +25,25 @@ def terminate_proc_gracefully(proc: subprocess.Popen) -> None:
 class TestE2EPrintURL(unittest.TestCase):
     def setUp(self) -> None:
         self.expected = secrets.token_hex(12)
-        self.script = f"print('{self.expected}')\n"
+        self.script = f"print('{self.expected}', end='')\n"
+
+    @cached_property
+    def qrrun_bin(self) -> str:
+        for candidate in ("./qrrun", "./qrrun.exe"):
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        return ""
 
     def test_require_cloudflared(self) -> None:
         self.assertIsNotNone(
             shutil.which("cloudflared"),
             "cloudflared is required for test-e2e",
+        )
+
+    def test_require_qrrun(self) -> None:
+        self.assertTrue(
+            self.qrrun_bin,
+            "qrrun executable is required for test-e2e",
         )
 
     def test_require_python3(self) -> None:
@@ -39,13 +55,13 @@ class TestE2EPrintURL(unittest.TestCase):
         self.assertRegex(
             version,
             r"^Python 3(\.|\s|$)",
-            f"python3 is required for test-e2e: got '{version}'",
+            f"python3 is required for test-e2e: got {version!r}",
         )
 
     def test_validate_url_roundtrip(self) -> None:
-        proc = subprocess.Popen(
+        qrrun = subprocess.Popen(
             [
-                "./qrrun",
+                self.qrrun_bin,
                 "--transport",
                 "cloudflared",
                 "--runtime",
@@ -58,21 +74,21 @@ class TestE2EPrintURL(unittest.TestCase):
             stderr=subprocess.DEVNULL,
             text=True,
         )
-        self.addCleanup(terminate_proc_gracefully, proc)
+        self.addCleanup(terminate_proc_gracefully, qrrun)
 
-        assert proc.stdin is not None
-        assert proc.stdout is not None
+        assert qrrun.stdin is not None
+        assert qrrun.stdout is not None
 
-        self.addCleanup(proc.stdin.close)
-        self.addCleanup(proc.stdout.close)
+        self.addCleanup(qrrun.stdin.close)
+        self.addCleanup(qrrun.stdout.close)
 
-        proc.stdin.write(self.script)
-        proc.stdin.close()
-        ready, _, _ = select.select([proc.stdout], [], [], 30.0)
+        qrrun.stdin.write(self.script)
+        qrrun.stdin.close()
+        ready, _, _ = select.select([qrrun.stdout], [], [], 30.0)
         if not ready:
             self.fail("timed out waiting for qrrun URL output")
 
-        url_line = proc.stdout.readline().strip()
+        url_line = qrrun.stdout.readline().strip()
         if not url_line:
             self.fail("qrrun exited without producing URL")
 
@@ -86,16 +102,36 @@ class TestE2EPrintURL(unittest.TestCase):
 
         time.sleep(5)
 
-        actual = subprocess.check_output(
-            ["python3", "-"],
-            input=code,
-            text=True,
-        ).strip()
+        python = subprocess.run(
+            [sys.executable, "-"],
+            input=dedent(
+                """
+                import builtins
+                import sys
 
+                def exec(source, *args, **kwargs):
+                    print(source, file=sys.stderr, end="")
+                    return builtins.exec(source, *args, **kwargs)
+                """
+            )
+            + code,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        actual = python.stdout
         self.assertEqual(
             actual,
             self.expected,
-            f"e2e mismatch: expected '{self.expected}', got '{actual}'",
+            f"output mismatch: expected {self.expected!r}, got {actual!r}",
+        )
+
+        transferred = python.stderr
+        self.assertEqual(
+            transferred,
+            self.script,
+            f"script mismatch: expected {self.script!r}, got {transferred!r}",
         )
 
 

--- a/scripts/e2e_print_url.py
+++ b/scripts/e2e_print_url.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 import os
+import queue
 import secrets
-import select
 import shutil
 import subprocess
 import sys
+import threading
 import time
 import unittest
 from functools import cached_property
@@ -20,6 +21,19 @@ def terminate_proc_gracefully(proc: subprocess.Popen) -> None:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
+
+
+def readline(stream, *, timeout: float) -> str:
+    result: queue.Queue[str] = queue.Queue(maxsize=1)
+    thread = threading.Thread(
+        target=lambda: result.put(stream.readline()), daemon=True
+    )
+    thread.start()
+
+    try:
+        return result.get(timeout=timeout)
+    except queue.Empty as exc:
+        raise TimeoutError("timed out waiting for qrrun URL output") from exc
 
 
 class TestE2EPrintURL(unittest.TestCase):
@@ -84,13 +98,10 @@ class TestE2EPrintURL(unittest.TestCase):
 
         qrrun.stdin.write(self.script)
         qrrun.stdin.close()
-        ready, _, _ = select.select([qrrun.stdout], [], [], 30.0)
-        if not ready:
-            self.fail("timed out waiting for qrrun URL output")
 
-        url_line = qrrun.stdout.readline().strip()
+        url_line = readline(qrrun.stdout, timeout=30.0).strip()
         if not url_line:
-            self.fail("qrrun exited without producing URL")
+            self.fail("qrrun outputs a valid URL")
 
         self.assertRegex(
             url_line,


### PR DESCRIPTION
## Summary
- add e2e-linux and e2e-windows CI jobs to run scripts/e2e_print_url.py continuously
- install cloudflared in CI (Linux via .deb, Windows via winget)
- make e2e_print_url.py work cross-platform by resolving qrrun/qrrun.exe and validating transferred script content
- use make test-e2e in both Linux and Windows jobs after setting up make on windows

## Validation
- pre-commit run --all-files
