### PR TITLE
Restructure README flow diagram and remove release section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,13 @@ jobs:
           cloudflared --version
 
       - name: Run E2E test
-        shell: bash
-        run: |
-          make test-e2e
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 2
+          shell: bash
+          command: make test-e2e
 
   e2e-windows:
     runs-on: windows-latest
@@ -131,6 +135,10 @@ jobs:
           & $exe --version
 
       - name: Run E2E test
-        shell: bash
-        run: |
-          make test-e2e
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 2
+          shell: bash
+          command: make test-e2e

--- a/README.md
+++ b/README.md
@@ -9,30 +9,6 @@ Tunnel local code. Run via QR.
 
 ![QRrun demo](demo.gif)
 
-```mermaid
-sequenceDiagram
-	autonumber
-	participant User as User
-	participant QRrun as QRrun
-	participant Cloudflare as Cloudflare
-	participant Camera as Camera App
-	participant Pythonista as Pythonista 3
-
-	User->>QRrun: Run qrrun <script|-> [args...]
-	QRrun->>QRrun: Start localhost server and register script endpoint
-	QRrun->>Cloudflare: Start cloudflared for quick tunnel to localhost server
-	Cloudflare-->>QRrun: Return public trycloudflare URL
-	QRrun-->>User: Render QR code (runtime URL)
-	User->>Camera: Open camera and scan QR code
-	Camera-->>Pythonista: Open pythonista3://?exec=...
-	Pythonista->>Cloudflare: Request script URL with token
-	Cloudflare->>QRrun: Forward HTTPS request to localhost server
-	QRrun-->>Cloudflare: Return script content
-	Cloudflare-->>Pythonista: Return script payload
-	Pythonista->>Pythonista: Execute script with args
-	Pythonista-->>User: Display script output
-```
-
 ## Prerequisites
 
 - `cloudflared` must be installed and available in your PATH.
@@ -84,6 +60,28 @@ pre-commit install
 make test-e2e
 ```
 
-## Release
+## Execution Flow
 
-For release operations, see [AGENTS.md](AGENTS.md).
+```mermaid
+sequenceDiagram
+	autonumber
+	participant User as User
+	participant QRrun as QRrun
+	participant Cloudflare as Cloudflare
+	participant Camera as Camera App
+	participant Pythonista as Pythonista 3
+
+	User->>QRrun: Run qrrun <script|-> [args...]
+	QRrun->>QRrun: Start localhost server and register script endpoint
+	QRrun->>Cloudflare: Start cloudflared for quick tunnel to localhost server
+	Cloudflare-->>QRrun: Return public trycloudflare URL
+	QRrun-->>User: Render QR code (runtime URL)
+	User->>Camera: Open camera and scan QR code
+	Camera-->>Pythonista: Open pythonista3://?exec=...
+	Pythonista->>Cloudflare: Request script URL with token
+	Cloudflare->>QRrun: Forward HTTPS request to localhost server
+	QRrun-->>Cloudflare: Return script content
+	Cloudflare-->>Pythonista: Return script payload
+	Pythonista->>Pythonista: Execute script with args
+	Pythonista-->>User: Display script output
+```


### PR DESCRIPTION
## Summary
- remove the Release section from README
- move the sequence diagram from below demo GIF to the bottom of README
- rename the section to Execution Flow
