### PR TITLE
Add Dependabot configuration for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary
- add Dependabot configuration file for repository-wide dependency updates
- enable weekly version updates for Go modules and GitHub Actions
- prepare repository for Dependabot security update PRs

## Details
- add .github/dependabot.yml
- schedule: every Monday at 04:00 Asia/Tokyo
- label Dependabot PRs with dependencies
