### PR TITLE
Add automated MSI installer validation

### DIFF
--- a/.github/workflows/msi-validation.yml
+++ b/.github/workflows/msi-validation.yml
@@ -1,0 +1,68 @@
+name: msi-validation
+
+'on':
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+      - .github/workflows/msi-validation.yml
+      - packaging/windows/**
+      - scripts/release_build_windows_msi.ps1
+      - scripts/validate_windows_msi.ps1
+      - cmd/qrrun/main.go
+      - go.mod
+      - go.sum
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-msi:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goarch: amd64
+            wix_arch: x64
+          - goarch: arm64
+            wix_arch: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install WiX Toolset
+        shell: powershell
+        run: |
+          choco install wixtoolset -y
+          echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Build MSI
+        shell: powershell
+        env:
+          VERSION: v0.0.0-beta.1
+          GOARCH: ${{ matrix.goarch }}
+          WIX_ARCH: ${{ matrix.wix_arch }}
+        run: |
+          ./scripts/release_build_windows_msi.ps1
+
+      - name: Validate MSI installer behavior
+        shell: powershell
+        env:
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          ./scripts/validate_windows_msi.ps1 -MsiPath "dist/qrrun_v0.0.0-beta.1_windows_${env:GOARCH}.msi" -GoArch $env:GOARCH
+
+      - name: Upload MSI validation logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: msi-validation-${{ matrix.goarch }}-logs
+          path: dist/msi-validation-logs/*.log
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,22 @@ jobs:
         run: |
           ./scripts/release_build_windows_msi.ps1
 
+      - name: Validate MSI installer behavior
+        shell: powershell
+        env:
+          VERSION: ${{ needs.guard-main.outputs.version }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          ./scripts/validate_windows_msi.ps1 -MsiPath "dist/qrrun_${env:VERSION}_windows_${env:GOARCH}.msi" -GoArch $env:GOARCH
+
+      - name: Upload MSI validation logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows-${{ matrix.goarch }}-msi-validation-logs
+          path: dist/msi-validation-logs/*.log
+          if-no-files-found: warn
+
       - name: Upload MSI artifact
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/validate_windows_msi.ps1
+++ b/scripts/validate_windows_msi.ps1
@@ -64,6 +64,55 @@ function Test-PathContainsEntry {
   return $false
 }
 
+function Get-PathEntryList {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('User', 'Machine')]
+    [string]$Target
+  )
+
+  $pathValue = [Environment]::GetEnvironmentVariable('Path', $Target)
+  if ([string]::IsNullOrWhiteSpace($pathValue)) {
+    return @()
+  }
+
+  return @(
+    $pathValue.Split(';') |
+      ForEach-Object { $_.Trim() } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+}
+
+function Resolve-QrrunInstallDir {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('User', 'Machine')]
+    [string]$Target,
+
+    [string[]]$PreferredDirs = @()
+  )
+
+  foreach ($entry in (Get-PathEntryList -Target $Target)) {
+    $exePath = Join-Path $entry 'qrrun.exe'
+    if (Test-Path -LiteralPath $exePath -PathType Leaf) {
+      return $entry
+    }
+  }
+
+  foreach ($dir in $PreferredDirs) {
+    if ([string]::IsNullOrWhiteSpace($dir)) {
+      continue
+    }
+
+    $exePath = Join-Path $dir 'qrrun.exe'
+    if (Test-Path -LiteralPath $exePath -PathType Leaf) {
+      return $dir
+    }
+  }
+
+  return $null
+}
+
 function Assert-PathEntryState {
   param(
     [Parameter(Mandatory = $true)]
@@ -168,9 +217,8 @@ function Test-InstallExecutionSupported {
     [string]$TargetGoArch
   )
 
-  $hostArch = $env:PROCESSOR_ARCHITECTURE.ToLowerInvariant()
-  if ($TargetGoArch -eq 'arm64' -and $hostArch -ne 'arm64') {
-    Write-Output "Skipping install flow tests for arm64 MSI on host architecture '$hostArch'"
+  if ($TargetGoArch -ne 'amd64') {
+    Write-Output "Skipping install flow tests for $TargetGoArch MSI on this runner"
     return $false
   }
 
@@ -179,13 +227,21 @@ function Test-InstallExecutionSupported {
 
 function Test-UserScope {
   $scopeArgs = 'ALLUSERS=2 MSIINSTALLPERUSER=1'
-  $installDir = Join-Path (Join-Path $env:LOCALAPPDATA 'Programs') 'qrrun'
-  $exePath = Join-Path $installDir 'qrrun.exe'
+  $preferredInstallDirs = @(
+    (Join-Path (Join-Path $env:LOCALAPPDATA 'Programs') 'qrrun'),
+    (Join-Path $env:LOCALAPPDATA 'qrrun')
+  )
 
   Write-Output 'Running user-scope install, repair, reinstall, and uninstall checks'
   Invoke-BestEffortUninstall -ScopeArguments $scopeArgs -OperationName 'cleanup-user-before'
 
   Invoke-MsiExec -OperationName 'install-user' -Arguments "/i `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" | Out-Null
+  $installDir = Resolve-QrrunInstallDir -Target User -PreferredDirs $preferredInstallDirs
+  if ($null -eq $installDir) {
+    throw "qrrun.exe was not found after user-scope install"
+  }
+
+  $exePath = Join-Path $installDir 'qrrun.exe'
   Assert-QrrunExecutable -ExePath $exePath
   Assert-PathEntryState -Target User -ExpectedEntry $installDir -ShouldExist $true
 
@@ -205,13 +261,21 @@ function Test-UserScope {
 
 function Test-MachineScope {
   $scopeArgs = 'ALLUSERS=1'
-  $installDir = Join-Path $env:ProgramFiles 'qrrun'
-  $exePath = Join-Path $installDir 'qrrun.exe'
+  $preferredInstallDirs = @(
+    (Join-Path $env:ProgramFiles 'qrrun'),
+    (Join-Path ${env:ProgramFiles(x86)} 'qrrun')
+  )
 
   Write-Output 'Running machine-scope install, repair, reinstall, and uninstall checks'
   Invoke-BestEffortUninstall -ScopeArguments $scopeArgs -OperationName 'cleanup-machine-before'
 
   Invoke-MsiExec -OperationName 'install-machine' -Arguments "/i `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" | Out-Null
+  $installDir = Resolve-QrrunInstallDir -Target Machine -PreferredDirs $preferredInstallDirs
+  if ($null -eq $installDir) {
+    throw "qrrun.exe was not found after machine-scope install"
+  }
+
+  $exePath = Join-Path $installDir 'qrrun.exe'
   Assert-QrrunExecutable -ExePath $exePath
   Assert-PathEntryState -Target Machine -ExpectedEntry $installDir -ShouldExist $true
 

--- a/scripts/validate_windows_msi.ps1
+++ b/scripts/validate_windows_msi.ps1
@@ -8,15 +8,6 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-function ConvertTo-NormalizedGuid {
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$GuidValue
-  )
-
-  return $GuidValue.Trim().TrimStart('{').TrimEnd('}').ToUpperInvariant()
-}
-
 function Get-MsiPropertyValue {
   param(
     [Parameter(Mandatory = $true)]
@@ -259,7 +250,12 @@ if ($productVersion -notmatch '^\d+\.\d+\.\d+\.\d+$') {
 }
 
 $expectedUpgradeCode = 'B1A2C8E2-3E4B-4F93-ABF7-D39C45FB0C6D'
-if ((ConvertTo-NormalizedGuid -GuidValue $upgradeCode) -ne $expectedUpgradeCode) {
+if ([string]::IsNullOrWhiteSpace([string]$upgradeCode)) {
+  throw 'UpgradeCode property is empty'
+}
+
+$normalizedUpgradeCode = ([string]$upgradeCode).Trim().TrimStart('{').TrimEnd('}').ToUpperInvariant()
+if ($normalizedUpgradeCode -ne $expectedUpgradeCode) {
   throw "Unexpected UpgradeCode '$upgradeCode'"
 }
 

--- a/scripts/validate_windows_msi.ps1
+++ b/scripts/validate_windows_msi.ps1
@@ -175,6 +175,22 @@ function Assert-QrrunExecutable {
   }
 }
 
+function Write-MsiLogOnFailure {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$LogPath
+  )
+
+  if (-not (Test-Path -LiteralPath $LogPath -PathType Leaf)) {
+    Write-Output "msiexec log file was not found: $LogPath"
+    return
+  }
+
+  Write-Output "----- Begin msiexec log: $LogPath -----"
+  Get-Content -LiteralPath $LogPath
+  Write-Output "----- End msiexec log: $LogPath -----"
+}
+
 function Invoke-MsiExec {
   param(
     [Parameter(Mandatory = $true)]
@@ -192,6 +208,7 @@ function Invoke-MsiExec {
   Write-Output "Running: msiexec.exe $fullArguments"
   $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList $fullArguments -NoNewWindow -Wait -PassThru
   if ($AllowedExitCodes -notcontains $process.ExitCode) {
+    Write-MsiLogOnFailure -LogPath $logPath
     throw "msiexec failed in '$OperationName' with exit code $($process.ExitCode). See $logPath"
   }
 
@@ -218,7 +235,7 @@ function Test-InstallExecutionSupported {
   )
 
   if ($TargetGoArch -ne 'amd64') {
-    Write-Output "Skipping install flow tests for $TargetGoArch MSI on this runner"
+    Write-Information "Skipping install flow tests for $TargetGoArch MSI on this runner" -InformationAction Continue
     return $false
   }
 

--- a/scripts/validate_windows_msi.ps1
+++ b/scripts/validate_windows_msi.ps1
@@ -1,0 +1,273 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$MsiPath,
+
+  [ValidateSet('amd64', 'arm64')]
+  [string]$GoArch = 'amd64'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-NormalizedGuid {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$GuidValue
+  )
+
+  return $GuidValue.Trim().TrimStart('{').TrimEnd('}').ToUpperInvariant()
+}
+
+function Get-MsiPropertyValue {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$Database,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PropertyName
+  )
+
+  $query = "SELECT `Value` FROM `Property` WHERE `Property`='$PropertyName'"
+  $view = $Database.OpenView($query)
+  $view.Execute()
+  $record = $view.Fetch()
+  if ($null -eq $record) {
+    throw "MSI property '$PropertyName' was not found"
+  }
+
+  return $record.StringData(1)
+}
+
+function ConvertTo-NormalizedPathValue {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PathValue
+  )
+
+  return $PathValue.Trim().Trim('"').TrimEnd('\\').ToLowerInvariant()
+}
+
+function Test-PathContainsEntry {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PathValue,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedEntry
+  )
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return $false
+  }
+
+  $normalizedExpected = ConvertTo-NormalizedPathValue -PathValue $ExpectedEntry
+  foreach ($entry in $PathValue.Split(';')) {
+    if ([string]::IsNullOrWhiteSpace($entry)) {
+      continue
+    }
+
+    if ((ConvertTo-NormalizedPathValue -PathValue $entry) -eq $normalizedExpected) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function Assert-PathEntryState {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('User', 'Machine')]
+    [string]$Target,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedEntry,
+
+    [Parameter(Mandatory = $true)]
+    [bool]$ShouldExist
+  )
+
+  $pathValue = [Environment]::GetEnvironmentVariable('Path', $Target)
+  $exists = Test-PathContainsEntry -PathValue $pathValue -ExpectedEntry $ExpectedEntry
+
+  if ($ShouldExist -and -not $exists) {
+    throw "Expected PATH entry '$ExpectedEntry' in $Target scope was not found"
+  }
+
+  if (-not $ShouldExist -and $exists) {
+    throw "PATH entry '$ExpectedEntry' in $Target scope should be removed"
+  }
+}
+
+function Assert-FileState {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    [Parameter(Mandatory = $true)]
+    [bool]$ShouldExist
+  )
+
+  $exists = Test-Path -LiteralPath $Path -PathType Leaf
+  if ($ShouldExist -and -not $exists) {
+    throw "Expected file was not found: $Path"
+  }
+
+  if (-not $ShouldExist -and $exists) {
+    throw "File should be removed but still exists: $Path"
+  }
+}
+
+function Assert-QrrunExecutable {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExePath
+  )
+
+  Assert-FileState -Path $ExePath -ShouldExist $true
+
+  $output = & $ExePath --version 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw "Executable check failed for '$ExePath'. Exit code: $LASTEXITCODE"
+  }
+
+  if ($output -notmatch 'commit:') {
+    throw "Unexpected version output from '$ExePath': $output"
+  }
+}
+
+function Invoke-MsiExec {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$OperationName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Arguments,
+
+    [int[]]$AllowedExitCodes = @(0, 3010)
+  )
+
+  $logPath = Join-Path $script:LogRoot "${OperationName}.log"
+  $fullArguments = "$Arguments /L*v `"$logPath`""
+
+  Write-Output "Running: msiexec.exe $fullArguments"
+  $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList $fullArguments -NoNewWindow -Wait -PassThru
+  if ($AllowedExitCodes -notcontains $process.ExitCode) {
+    throw "msiexec failed in '$OperationName' with exit code $($process.ExitCode). See $logPath"
+  }
+
+  return $logPath
+}
+
+function Invoke-BestEffortUninstall {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScopeArguments,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OperationName
+  )
+
+  Invoke-MsiExec -OperationName $OperationName -Arguments "/x `"$script:ResolvedMsiPath`" /qn /norestart $ScopeArguments" -AllowedExitCodes @(0, 3010, 1605, 1614) | Out-Null
+}
+
+function Test-InstallExecutionSupported {
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('amd64', 'arm64')]
+    [string]$TargetGoArch
+  )
+
+  $hostArch = $env:PROCESSOR_ARCHITECTURE.ToLowerInvariant()
+  if ($TargetGoArch -eq 'arm64' -and $hostArch -ne 'arm64') {
+    Write-Output "Skipping install flow tests for arm64 MSI on host architecture '$hostArch'"
+    return $false
+  }
+
+  return $true
+}
+
+function Test-UserScope {
+  $scopeArgs = 'ALLUSERS=2 MSIINSTALLPERUSER=1'
+  $installDir = Join-Path (Join-Path $env:LOCALAPPDATA 'Programs') 'qrrun'
+  $exePath = Join-Path $installDir 'qrrun.exe'
+
+  Write-Output 'Running user-scope install, repair, reinstall, and uninstall checks'
+  Invoke-BestEffortUninstall -ScopeArguments $scopeArgs -OperationName 'cleanup-user-before'
+
+  Invoke-MsiExec -OperationName 'install-user' -Arguments "/i `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" | Out-Null
+  Assert-QrrunExecutable -ExePath $exePath
+  Assert-PathEntryState -Target User -ExpectedEntry $installDir -ShouldExist $true
+
+  Remove-Item -LiteralPath $exePath -Force
+  Assert-FileState -Path $exePath -ShouldExist $false
+
+  Invoke-MsiExec -OperationName 'repair-user' -Arguments "/fa `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs REINSTALL=ALL REINSTALLMODE=vomus" | Out-Null
+  Assert-QrrunExecutable -ExePath $exePath
+
+  Invoke-MsiExec -OperationName 'reinstall-user' -Arguments "/i `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" | Out-Null
+  Assert-QrrunExecutable -ExePath $exePath
+
+  Invoke-MsiExec -OperationName 'uninstall-user' -Arguments "/x `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" -AllowedExitCodes @(0, 3010, 1605, 1614) | Out-Null
+  Assert-FileState -Path $exePath -ShouldExist $false
+  Assert-PathEntryState -Target User -ExpectedEntry $installDir -ShouldExist $false
+}
+
+function Test-MachineScope {
+  $scopeArgs = 'ALLUSERS=1'
+  $installDir = Join-Path $env:ProgramFiles 'qrrun'
+  $exePath = Join-Path $installDir 'qrrun.exe'
+
+  Write-Output 'Running machine-scope install, repair, reinstall, and uninstall checks'
+  Invoke-BestEffortUninstall -ScopeArguments $scopeArgs -OperationName 'cleanup-machine-before'
+
+  Invoke-MsiExec -OperationName 'install-machine' -Arguments "/i `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" | Out-Null
+  Assert-QrrunExecutable -ExePath $exePath
+  Assert-PathEntryState -Target Machine -ExpectedEntry $installDir -ShouldExist $true
+
+  Remove-Item -LiteralPath $exePath -Force
+  Assert-FileState -Path $exePath -ShouldExist $false
+
+  Invoke-MsiExec -OperationName 'repair-machine' -Arguments "/fa `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs REINSTALL=ALL REINSTALLMODE=vomus" | Out-Null
+  Assert-QrrunExecutable -ExePath $exePath
+
+  Invoke-MsiExec -OperationName 'reinstall-machine' -Arguments "/i `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" | Out-Null
+  Assert-QrrunExecutable -ExePath $exePath
+
+  Invoke-MsiExec -OperationName 'uninstall-machine' -Arguments "/x `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" -AllowedExitCodes @(0, 3010, 1605, 1614) | Out-Null
+  Assert-FileState -Path $exePath -ShouldExist $false
+  Assert-PathEntryState -Target Machine -ExpectedEntry $installDir -ShouldExist $false
+}
+
+$script:ResolvedMsiPath = (Resolve-Path -Path $MsiPath).Path
+$script:LogRoot = Join-Path (Split-Path -Parent $script:ResolvedMsiPath) 'msi-validation-logs'
+New-Item -ItemType Directory -Path $script:LogRoot -Force | Out-Null
+
+Write-Output "Validating MSI metadata: $script:ResolvedMsiPath"
+$installer = New-Object -ComObject WindowsInstaller.Installer
+$database = $installer.OpenDatabase($script:ResolvedMsiPath, 0)
+
+$productName = Get-MsiPropertyValue -Database $database -PropertyName 'ProductName'
+$productVersion = Get-MsiPropertyValue -Database $database -PropertyName 'ProductVersion'
+$upgradeCode = Get-MsiPropertyValue -Database $database -PropertyName 'UpgradeCode'
+
+if ($productName -ne 'qrrun') {
+  throw "Unexpected ProductName '$productName'"
+}
+
+if ($productVersion -notmatch '^\d+\.\d+\.\d+\.\d+$') {
+  throw "Unexpected ProductVersion format '$productVersion'"
+}
+
+$expectedUpgradeCode = 'B1A2C8E2-3E4B-4F93-ABF7-D39C45FB0C6D'
+if ((ConvertTo-NormalizedGuid -GuidValue $upgradeCode) -ne $expectedUpgradeCode) {
+  throw "Unexpected UpgradeCode '$upgradeCode'"
+}
+
+Write-Output "MSI metadata validated (ProductVersion=$productVersion)"
+
+if (Test-InstallExecutionSupported -TargetGoArch $GoArch) {
+  Test-UserScope
+  Test-MachineScope
+}
+
+Write-Output "MSI validation completed successfully. Logs: $script:LogRoot"


### PR DESCRIPTION
## Summary
- add automated MSI installer validation script for metadata and install behavior
- add dedicated Windows PR workflow for MSI build and validation
- run MSI validation in release workflow before publishing release artifacts

## Changes
- add scripts/validate_windows_msi.ps1
- add .github/workflows/msi-validation.yml
- update .github/workflows/release.yml build-msi job

## Validation
- pre-commit run --all-files
