### PR TITLE
Automate Homebrew installation release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,6 +322,5 @@ jobs:
           VERSION: ${{ needs.guard-main.outputs.version }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
-          HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO }}
         run: |
           bash ./scripts/release_open_homebrew_tap_pr.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,3 +290,38 @@ jobs:
           QRRUN_GITHUB_TOKEN: ${{ github.token }}
         run: |
           bash ./scripts/release_open_winget_pr.sh
+
+  homebrew-tap-pr:
+    runs-on: ubuntu-latest
+    needs:
+      - guard-main
+      - release
+    if: needs.guard-main.outputs.on_main == 'true' && !contains(needs.guard-main.outputs.version, '-alpha') && !contains(needs.guard-main.outputs.version, '-beta') && !contains(needs.guard-main.outputs.version, '-rc')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check HOMEBREW_TAP_PAT
+        id: token
+        shell: bash
+        env:
+          HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+        run: |
+          if [ -z "${HOMEBREW_TAP_PAT}" ]; then
+            echo "::warning::HOMEBREW_TAP_PAT is not set. Skipping homebrew-tap PR automation."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open homebrew-tap PR
+        if: steps.token.outputs.enabled == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ needs.guard-main.outputs.version }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+          HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO }}
+        run: |
+          bash ./scripts/release_open_homebrew_tap_pr.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation
 
-## Linux / macOS
+## Linux
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sakurai-youhei/qrrun/main/scripts/install.sh | bash
@@ -10,6 +10,20 @@ Install a specific version:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sakurai-youhei/qrrun/main/scripts/install.sh | bash -s -- v0.1.0
+```
+
+## macOS (Homebrew)
+
+Install the latest release:
+
+```bash
+brew install --formula https://github.com/sakurai-youhei/qrrun/releases/latest/download/qrrun.rb
+```
+
+Install a specific version:
+
+```bash
+brew install --formula https://github.com/sakurai-youhei/qrrun/releases/download/v0.1.3/qrrun.rb
 ```
 
 ## Windows

--- a/scripts/release_generate_homebrew_formula.sh
+++ b/scripts/release_generate_homebrew_formula.sh
@@ -30,9 +30,9 @@ class Qrrun < Formula
 
   def install
     if Hardware::CPU.intel?
-      bin.install "qrrun_#{version}_darwin_amd64" => "qrrun"
+      bin.install "qrrun_v#{version}_darwin_amd64" => "qrrun"
     else
-      bin.install "qrrun_#{version}_darwin_arm64" => "qrrun"
+      bin.install "qrrun_v#{version}_darwin_arm64" => "qrrun"
     end
   end
 

--- a/scripts/release_open_homebrew_tap_pr.sh
+++ b/scripts/release_open_homebrew_tap_pr.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${VERSION:?VERSION is required}"
+HOMEBREW_TAP_PAT="${HOMEBREW_TAP_PAT:?HOMEBREW_TAP_PAT is required}"
+SOURCE_REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+SOURCE_OWNER="${SOURCE_REPO%%/*}"
+HOMEBREW_TAP_REPO="${HOMEBREW_TAP_REPO:-${SOURCE_OWNER}/homebrew-tap}"
+TAP_OWNER="${HOMEBREW_TAP_REPO%%/*}"
+FORMULA_PATH="${HOMEBREW_FORMULA_PATH:-Formula/qrrun.rb}"
+
+VERSION_NO_V="${VERSION#v}"
+if [[ "${VERSION_NO_V}" =~ -(alpha|beta|rc)(\.|$) ]]; then
+  echo "Skipping homebrew-tap PR for pre-release tag: ${VERSION}"
+  exit 0
+fi
+
+export GH_TOKEN="${HOMEBREW_TAP_PAT}"
+if ! gh repo view "${HOMEBREW_TAP_REPO}" >/dev/null 2>&1; then
+  echo "::warning::Homebrew tap repository is not accessible: ${HOMEBREW_TAP_REPO}. Skipping automation."
+  exit 0
+fi
+
+DEFAULT_BRANCH="$(gh repo view "${HOMEBREW_TAP_REPO}" --json defaultBranchRef --jq '.defaultBranchRef.name')"
+if [[ -z "${DEFAULT_BRANCH}" || "${DEFAULT_BRANCH}" == "null" ]]; then
+  DEFAULT_BRANCH="main"
+fi
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+FORMULA_URL="https://github.com/${SOURCE_REPO}/releases/download/${VERSION}/qrrun.rb"
+echo "Downloading Homebrew formula from ${FORMULA_URL}"
+curl -fsSL -o "${TMP_DIR}/qrrun.rb" "${FORMULA_URL}"
+
+if ! grep -q '^class Qrrun < Formula$' "${TMP_DIR}/qrrun.rb"; then
+  echo "Downloaded formula does not look valid: ${FORMULA_URL}"
+  exit 1
+fi
+
+echo "Cloning ${HOMEBREW_TAP_REPO}"
+git clone "https://x-access-token:${HOMEBREW_TAP_PAT}@github.com/${HOMEBREW_TAP_REPO}.git" "${TMP_DIR}/homebrew-tap"
+
+cd "${TMP_DIR}/homebrew-tap"
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git switch "${DEFAULT_BRANCH}"
+
+BRANCH_NAME="qrrun-${VERSION_NO_V}"
+if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+  git switch --track "origin/${BRANCH_NAME}"
+else
+  git switch -c "${BRANCH_NAME}"
+fi
+
+mkdir -p "$(dirname "${FORMULA_PATH}")"
+cp "${TMP_DIR}/qrrun.rb" "${FORMULA_PATH}"
+
+if git diff --quiet -- "${FORMULA_PATH}"; then
+  echo "No formula changes detected. Skipping commit and PR creation."
+  exit 0
+fi
+
+git add "${FORMULA_PATH}"
+git commit -m "Update qrrun to ${VERSION}"
+git push --set-upstream origin "${BRANCH_NAME}"
+
+EXISTING_PR_NUMBER="$(gh pr list --repo "${HOMEBREW_TAP_REPO}" --head "${TAP_OWNER}:${BRANCH_NAME}" --state open --json number --jq '.[0].number')"
+if [[ -n "${EXISTING_PR_NUMBER}" && "${EXISTING_PR_NUMBER}" != "null" ]]; then
+  echo "Homebrew tap PR already exists: #${EXISTING_PR_NUMBER}"
+  exit 0
+fi
+
+PR_BODY_FILE="${TMP_DIR}/homebrew-pr-body.md"
+cat >"${PR_BODY_FILE}" <<EOF
+## Summary
+- Update qrrun formula to ${VERSION}
+
+## Source Release
+- https://github.com/${SOURCE_REPO}/releases/tag/${VERSION}
+EOF
+
+gh pr create \
+  --repo "${HOMEBREW_TAP_REPO}" \
+  --base "${DEFAULT_BRANCH}" \
+  --head "${TAP_OWNER}:${BRANCH_NAME}" \
+  --title "Update qrrun to ${VERSION}" \
+  --body-file "${PR_BODY_FILE}"


### PR DESCRIPTION
## Summary
- add release automation to open Homebrew tap PRs for stable tags
- fix generated Homebrew formula install path to match packaged darwin binary names
- add macOS Homebrew install instructions to INSTALL.md

## Details
- add scripts/release_open_homebrew_tap_pr.sh
- add homebrew-tap-pr job to .github/workflows/release.yml
- skip Homebrew tap automation for pre-release tags (alpha, beta, rc)
- keep automation opt-in via HOMEBREW_TAP_PAT secret

## Verification
- bash -n scripts/release_open_homebrew_tap_pr.sh
- bash -n scripts/release_generate_homebrew_formula.sh
- pre-commit run --all-files
- go test ./...
