### PR TITLE
ci: track Homebrew release updates with qrrun issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,5 +322,6 @@ jobs:
           VERSION: ${{ needs.guard-main.outputs.version }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           HOMEBREW_TAP_PAT: ${{ secrets.HOMEBREW_TAP_PAT }}
+          QRRUN_GITHUB_TOKEN: ${{ github.token }}
         run: |
           bash ./scripts/release_open_homebrew_tap_pr.sh

--- a/scripts/release_open_homebrew_tap_pr.sh
+++ b/scripts/release_open_homebrew_tap_pr.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 VERSION="${VERSION:?VERSION is required}"
 HOMEBREW_TAP_PAT="${HOMEBREW_TAP_PAT:?HOMEBREW_TAP_PAT is required}"
+QRRUN_GITHUB_TOKEN="${QRRUN_GITHUB_TOKEN:?QRRUN_GITHUB_TOKEN is required}"
 SOURCE_REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
 SOURCE_OWNER="${SOURCE_REPO%%/*}"
@@ -70,8 +71,32 @@ git add "${FORMULA_PATH}"
 git commit -m "Update qrrun to ${VERSION}"
 git push --set-upstream origin "${BRANCH_NAME}"
 
+ISSUE_TITLE="Release: update Homebrew tap for qrrun ${VERSION_NO_V}"
+EXISTING_ISSUE_NUMBER="$(GH_TOKEN="${QRRUN_GITHUB_TOKEN}" gh issue list --repo "${SOURCE_REPO}" --state open --search "\"${ISSUE_TITLE}\" in:title" --json number --jq '.[0].number')"
+
+if [[ -n "${EXISTING_ISSUE_NUMBER}" && "${EXISTING_ISSUE_NUMBER}" != "null" ]]; then
+  ISSUE_URL="$(GH_TOKEN="${QRRUN_GITHUB_TOKEN}" gh issue view "${EXISTING_ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --json url --jq '.url')"
+else
+  ISSUE_BODY_FILE="${TMP_DIR}/qrrun-homebrew-release-issue.md"
+  cat >"${ISSUE_BODY_FILE}" <<EOF
+## Summary
+- Track homebrew-tap submission for qrrun ${VERSION_NO_V}
+
+## Release
+- qrrun release tag: ${VERSION}
+- source repo: https://github.com/${SOURCE_REPO}
+
+## Homebrew Tap
+- tap repo: https://github.com/${HOMEBREW_TAP_REPO}
+- target branch: ${BRANCH_NAME}
+EOF
+
+  ISSUE_URL="$(GH_TOKEN="${QRRUN_GITHUB_TOKEN}" gh issue create --repo "${SOURCE_REPO}" --title "${ISSUE_TITLE}" --body-file "${ISSUE_BODY_FILE}")"
+fi
+
 EXISTING_PR_NUMBER="$(gh pr list --repo "${HOMEBREW_TAP_REPO}" --head "${TAP_OWNER}:${BRANCH_NAME}" --state open --json number --jq '.[0].number')"
 if [[ -n "${EXISTING_PR_NUMBER}" && "${EXISTING_PR_NUMBER}" != "null" ]]; then
+  gh pr comment --repo "${HOMEBREW_TAP_REPO}" "${EXISTING_PR_NUMBER}" --body "qrrun tracking issue: ${ISSUE_URL}"
   echo "Homebrew tap PR already exists: #${EXISTING_PR_NUMBER}"
   exit 0
 fi
@@ -83,6 +108,9 @@ cat >"${PR_BODY_FILE}" <<EOF
 
 ## Source Release
 - https://github.com/${SOURCE_REPO}/releases/tag/${VERSION}
+
+## Tracking
+- qrrun issue: ${ISSUE_URL}
 EOF
 
 gh pr create \


### PR DESCRIPTION
## Summary
- open or reuse a qrrun tracking issue for each stable homebrew release update
- include the qrrun tracking issue URL in homebrew-tap PR body
- pass qrrun GitHub token to the homebrew release automation step

## Changes
- update scripts/release_open_homebrew_tap_pr.sh
- update .github/workflows/release.yml

## Notes
- pre-release tags (alpha, beta, rc) remain skipped
- if a homebrew-tap PR already exists, the workflow comments with the tracking issue URL
