### PR TITLE
chore: switch shellcheck pre-commit repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
       - id: trailing-whitespace
       - id: mixed-line-ending
 
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.11.0
     hooks:
       - id: shellcheck
         files: \.sh$


### PR DESCRIPTION
## Summary
- switch the shellcheck pre-commit hook source to the official koalaman repository
- update shellcheck hook revision to v0.11.0

## Validation
- pre-commit run shellcheck --all-files
- pre-commit run shellcheck --files ./scripts/release_generate_homebrew_formula.sh ./scripts/release_open_homebrew_tap_pr.sh ./scripts/release_open_linux_packages_pr.sh ./scripts/release_open_winget_pr.sh ./scripts/release_package_deb.sh ./scripts/release_package_rpm.sh
