### PR TITLE
chore: align PowerShell script consistency

### DIFF
--- a/scripts/precommit_psscriptanalyzer.ps1
+++ b/scripts/precommit_psscriptanalyzer.ps1
@@ -4,25 +4,62 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ($PSVersionTable.PSVersion.Major -ge 7) {
+  $PSNativeCommandUseErrorActionPreference = $true
+}
+
+function Write-Step {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  Write-Output "[psscriptanalyzer] $Message"
+}
+
+Write-Step 'Ensuring PSScriptAnalyzer module is available'
 
 $module = Get-Module -ListAvailable -Name PSScriptAnalyzer |
   Sort-Object Version -Descending |
   Select-Object -First 1
 
 if (-not $module) {
+  Write-Step 'Installing PSScriptAnalyzer module'
   Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force -AllowClobber
 }
 
-Import-Module PSScriptAnalyzer
+Import-Module PSScriptAnalyzer -ErrorAction Stop
+
+$resolvedPaths = @()
+foreach ($path in $Paths) {
+  if ([string]::IsNullOrWhiteSpace($path)) {
+    continue
+  }
+
+  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+    throw "File not found for analysis: $path"
+  }
+
+  $resolvedPaths += (Resolve-Path -LiteralPath $path).Path
+}
+
+if ($resolvedPaths.Count -eq 0) {
+  Write-Step 'No PowerShell files provided. Skipping analysis.'
+  exit 0
+}
 
 $issues = @()
-foreach ($path in $Paths) {
-  if (-not [string]::IsNullOrWhiteSpace($path)) {
-    $issues += Invoke-ScriptAnalyzer -Path $path -Severity Error,Warning,Information
-  }
+foreach ($path in $resolvedPaths) {
+  Write-Step "Analyzing $path"
+  $issues += Invoke-ScriptAnalyzer -Path $path -Severity Error,Warning,Information
 }
 
 if ($issues) {
+  Write-Step "Found $($issues.Count) issue(s)"
   $issues | Format-Table -AutoSize
   exit 1
 }
+
+Write-Step 'No issues found'

--- a/scripts/release_build_windows_msi.ps1
+++ b/scripts/release_build_windows_msi.ps1
@@ -1,22 +1,101 @@
+param(
+  [string]$Version,
+  [string]$GithubSha,
+  [string]$GoArch,
+  [string]$WixArch
+)
+
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
-$date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-$githubSha = "${env:GITHUB_SHA}"
-$commit = "unknown"
-if (-not [string]::IsNullOrEmpty($githubSha) -and $githubSha.Length -ge 7) {
-  $commit = $githubSha.Substring(0, 7)
+if ($PSVersionTable.PSVersion.Major -ge 7) {
+  $PSNativeCommandUseErrorActionPreference = $true
 }
-$effectiveVersion = "${env:VERSION}"
-if ([string]::IsNullOrWhiteSpace($effectiveVersion)) {
-  $effectiveVersion = "v0.0.0-dev"
+
+function Write-Step {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  Write-Output "[build-msi] $Message"
 }
-$base = "qrrun_${effectiveVersion}_windows_${env:GOARCH}"
 
-New-Item -ItemType Directory -Path dist -Force | Out-Null
+function Resolve-InputValue {
+  param(
+    [string]$CliValue,
+    [string]$EnvValue,
+    [string]$DefaultValue
+  )
 
-$env:CGO_ENABLED = "0"
-$env:GOOS = "windows"
-go build -trimpath -ldflags "-s -w -X 'main.version=${effectiveVersion}' -X 'main.commit=${commit}' -X 'main.date=${date}'" -o "dist/${base}.exe" ./cmd/qrrun
+  if (-not [string]::IsNullOrWhiteSpace($CliValue)) {
+    return $CliValue
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($EnvValue)) {
+    return $EnvValue
+  }
+
+  return $DefaultValue
+}
+
+function Invoke-NativeCommand {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FilePath,
+
+    [string[]]$Arguments = @()
+  )
+
+  Write-Step "Running: $FilePath $($Arguments -join ' ')"
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "Command failed: $FilePath (exit code: $LASTEXITCODE)"
+  }
+}
+
+$effectiveVersion = Resolve-InputValue -CliValue $Version -EnvValue $env:VERSION -DefaultValue 'v0.0.0-dev'
+$effectiveGithubSha = Resolve-InputValue -CliValue $GithubSha -EnvValue $env:GITHUB_SHA -DefaultValue ''
+$effectiveGoArch = Resolve-InputValue -CliValue $GoArch -EnvValue $env:GOARCH -DefaultValue 'amd64'
+$effectiveWixArch = Resolve-InputValue -CliValue $WixArch -EnvValue $env:WIX_ARCH -DefaultValue $(if ($effectiveGoArch -eq 'arm64') { 'arm64' } else { 'x64' })
+
+if (@('amd64', 'arm64') -notcontains $effectiveGoArch) {
+  throw "GOARCH must be one of: amd64, arm64 (actual: '$effectiveGoArch')"
+}
+
+if (@('x64', 'arm64') -notcontains $effectiveWixArch) {
+  throw "WIX_ARCH must be one of: x64, arm64 (actual: '$effectiveWixArch')"
+}
+
+$date = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+$commit = 'unknown'
+if (-not [string]::IsNullOrEmpty($effectiveGithubSha) -and $effectiveGithubSha.Length -ge 7) {
+  $commit = $effectiveGithubSha.Substring(0, 7)
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$distDir = Join-Path $repoRoot 'dist'
+New-Item -ItemType Directory -Path $distDir -Force | Out-Null
+
+$base = "qrrun_${effectiveVersion}_windows_${effectiveGoArch}"
+$exePath = Join-Path $distDir "${base}.exe"
+$wxsPath = Join-Path $distDir "${base}.wxs"
+$wixObjPath = Join-Path $distDir "${base}.wixobj"
+$msiPath = Join-Path $distDir "${base}.msi"
+$wxsTemplatePath = Join-Path $repoRoot 'packaging/windows/qrrun.wxs'
+$binarySource = "dist/${base}.exe"
+
+$env:CGO_ENABLED = '0'
+$env:GOOS = 'windows'
+
+Write-Step "Building Windows executable for $effectiveVersion ($effectiveGoArch)"
+Invoke-NativeCommand -FilePath 'go' -Arguments @(
+  'build',
+  '-trimpath',
+  '-ldflags', "-s -w -X 'main.version=${effectiveVersion}' -X 'main.commit=${commit}' -X 'main.date=${date}'",
+  '-o', $exePath,
+  './cmd/qrrun'
+)
 
 $match = [regex]::Match($effectiveVersion, '^[vV]?(\d+)\.(\d+)\.(\d+)(?:-[A-Za-z]+\.(\d+))?')
 if (-not $match.Success) {
@@ -32,10 +111,24 @@ if ($match.Groups[4].Success) {
 }
 
 $productVersion = "$major.$minor.$patch.$build"
-$wxsTemplate = Get-Content packaging/windows/qrrun.wxs -Raw
-$wxsRendered = $wxsTemplate.Replace('$(var.ProductVersion)', $productVersion).Replace('$(var.BinarySource)', "dist/${base}.exe")
-$wxsPath = "dist/${base}.wxs"
-Set-Content -Path $wxsPath -Value $wxsRendered -NoNewline
 
-candle -nologo -arch $env:WIX_ARCH -out "dist/${base}.wixobj" $wxsPath
-light -nologo -ext WixUIExtension -out "dist/${base}.msi" "dist/${base}.wixobj"
+Write-Step "Rendering WiX template with ProductVersion=$productVersion"
+$wxsTemplate = Get-Content -LiteralPath $wxsTemplatePath -Raw
+$wxsRendered = $wxsTemplate.Replace('$(var.ProductVersion)', $productVersion).Replace('$(var.BinarySource)', $binarySource)
+Set-Content -LiteralPath $wxsPath -Value $wxsRendered -NoNewline
+
+Invoke-NativeCommand -FilePath 'candle' -Arguments @(
+  '-nologo',
+  '-arch', $effectiveWixArch,
+  '-out', $wixObjPath,
+  $wxsPath
+)
+
+Invoke-NativeCommand -FilePath 'light' -Arguments @(
+  '-nologo',
+  '-ext', 'WixUIExtension',
+  '-out', $msiPath,
+  $wixObjPath
+)
+
+Write-Step "MSI build completed: $msiPath"

--- a/scripts/validate_windows_msi.ps1
+++ b/scripts/validate_windows_msi.ps1
@@ -1,5 +1,6 @@
 param(
   [Parameter(Mandatory = $true)]
+  [ValidateNotNullOrEmpty()]
   [string]$MsiPath,
 
   [ValidateSet('amd64', 'arm64')]
@@ -7,6 +8,20 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ($PSVersionTable.PSVersion.Major -ge 7) {
+  $PSNativeCommandUseErrorActionPreference = $true
+}
+
+function Write-Step {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Message
+  )
+
+  Write-Output "[validate-msi] $Message"
+}
 
 function Get-MsiPropertyValue {
   param(
@@ -182,13 +197,13 @@ function Write-MsiLogOnFailure {
   )
 
   if (-not (Test-Path -LiteralPath $LogPath -PathType Leaf)) {
-    Write-Output "msiexec log file was not found: $LogPath"
+    Write-Step "msiexec log file was not found: $LogPath"
     return
   }
 
-  Write-Output "----- Begin msiexec log: $LogPath -----"
+  Write-Step "----- Begin msiexec log: $LogPath -----"
   Get-Content -LiteralPath $LogPath
-  Write-Output "----- End msiexec log: $LogPath -----"
+  Write-Step "----- End msiexec log: $LogPath -----"
 }
 
 function Invoke-MsiExec {
@@ -205,7 +220,7 @@ function Invoke-MsiExec {
   $logPath = Join-Path $script:LogRoot "${OperationName}.log"
   $fullArguments = "$Arguments /L*v `"$logPath`""
 
-  Write-Output "Running: msiexec.exe $fullArguments"
+  Write-Step "Running: msiexec.exe $fullArguments"
   $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList $fullArguments -NoNewWindow -Wait -PassThru
   if ($AllowedExitCodes -notcontains $process.ExitCode) {
     Write-MsiLogOnFailure -LogPath $logPath
@@ -235,7 +250,7 @@ function Test-InstallExecutionSupported {
   )
 
   if ($TargetGoArch -ne 'amd64') {
-    Write-Information "Skipping install flow tests for $TargetGoArch MSI on this runner" -InformationAction Continue
+    Write-Step "Skipping install flow tests for $TargetGoArch MSI on this runner"
     return $false
   }
 
@@ -249,7 +264,7 @@ function Test-UserScope {
     (Join-Path $env:LOCALAPPDATA 'qrrun')
   )
 
-  Write-Output 'Running user-scope install, repair, reinstall, and uninstall checks'
+  Write-Step 'Running user-scope install, repair, reinstall, and uninstall checks'
   Invoke-BestEffortUninstall -ScopeArguments $scopeArgs -OperationName 'cleanup-user-before'
 
   Invoke-MsiExec -OperationName 'install-user' -Arguments "/i `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" | Out-Null
@@ -283,7 +298,7 @@ function Test-MachineScope {
     (Join-Path ${env:ProgramFiles(x86)} 'qrrun')
   )
 
-  Write-Output 'Running machine-scope install, repair, reinstall, and uninstall checks'
+  Write-Step 'Running machine-scope install, repair, reinstall, and uninstall checks'
   Invoke-BestEffortUninstall -ScopeArguments $scopeArgs -OperationName 'cleanup-machine-before'
 
   Invoke-MsiExec -OperationName 'install-machine' -Arguments "/i `"$script:ResolvedMsiPath`" /qn /norestart $scopeArgs" | Out-Null
@@ -310,11 +325,11 @@ function Test-MachineScope {
   Assert-PathEntryState -Target Machine -ExpectedEntry $installDir -ShouldExist $false
 }
 
-$script:ResolvedMsiPath = (Resolve-Path -Path $MsiPath).Path
+$script:ResolvedMsiPath = (Resolve-Path -LiteralPath $MsiPath).Path
 $script:LogRoot = Join-Path (Split-Path -Parent $script:ResolvedMsiPath) 'msi-validation-logs'
 New-Item -ItemType Directory -Path $script:LogRoot -Force | Out-Null
 
-Write-Output "Validating MSI metadata: $script:ResolvedMsiPath"
+Write-Step "Validating MSI metadata: $script:ResolvedMsiPath"
 $installer = New-Object -ComObject WindowsInstaller.Installer
 $database = $installer.OpenDatabase($script:ResolvedMsiPath, 0)
 
@@ -340,11 +355,11 @@ if ($normalizedUpgradeCode -ne $expectedUpgradeCode) {
   throw "Unexpected UpgradeCode '$upgradeCode'"
 }
 
-Write-Output "MSI metadata validated (ProductVersion=$productVersion)"
+Write-Step "MSI metadata validated (ProductVersion=$productVersion)"
 
 if (Test-InstallExecutionSupported -TargetGoArch $GoArch) {
   Test-UserScope
   Test-MachineScope
 }
 
-Write-Output "MSI validation completed successfully. Logs: $script:LogRoot"
+Write-Step "MSI validation completed successfully. Logs: $script:LogRoot"


### PR DESCRIPTION
## Summary
- align PowerShell scripts under scripts/ with a consistent style for input contracts, path handling, and step logging
- add explicit native command failure handling to the MSI build script
- apply strict mode and PowerShell 7 native command error behavior consistently

## Changes
- scripts/release_build_windows_msi.ps1
  - add parameterized inputs (`Version`, `GithubSha`, `GoArch`, `WixArch`) while preserving env-var defaults
  - introduce `Invoke-NativeCommand` for explicit exit-code validation of `go`, `candle`, and `light`
  - normalize path construction with `Join-Path` and repo-root-based locations
  - add structured step logs (`[build-msi] ...`)
- scripts/precommit_psscriptanalyzer.ps1
  - add strict mode and optional PS7 native command error behavior
  - normalize and validate file paths via `Test-Path -LiteralPath` and `Resolve-Path -LiteralPath`
  - add structured step logs (`[psscriptanalyzer] ...`)
- scripts/validate_windows_msi.ps1
  - add strict mode and optional PS7 native command error behavior
  - use `Resolve-Path -LiteralPath` for MSI input
  - standardize step/log output to `[validate-msi] ...`

## Validation
- pre-commit run psscriptanalyzer --files scripts/precommit_psscriptanalyzer.ps1 scripts/release_build_windows_msi.ps1 scripts/validate_windows_msi.ps1
- pre-commit hooks on commit (including `go vet` and `go test`)
