### PR TITLE
fix: keep arm64 MSI validation skip guard reliable

### DIFF
--- a/scripts/validate_windows_msi.ps1
+++ b/scripts/validate_windows_msi.ps1
@@ -20,7 +20,7 @@ function Write-Step {
     [string]$Message
   )
 
-  Write-Output "[validate-msi] $Message"
+  Write-Information "[validate-msi] $Message" -InformationAction Continue
 }
 
 function Get-MsiPropertyValue {


### PR DESCRIPTION
## Summary
- Fix MSI validation logging so helper functions do not leak log text into return values
- Keep install-flow skip guard reliable for non-amd64 targets (arm64)

## Root Cause
- `Write-Step` used `Write-Output`, which writes to the success/output stream
- In `if (Test-InstallExecutionSupported ...)`, that output could make the condition truthy even when the function returned `$false`
- On arm64 lane this led to running install flow and failing with msiexec exit code 1633

## Change
- Replace `Write-Output` with `Write-Information -InformationAction Continue` in `scripts/validate_windows_msi.ps1`

## Validation
- pre-commit hooks passed (including PSScriptAnalyzer)
- go vet passed
- go test passed
