### PR TITLE
docs: link install failure note to issue form

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,7 @@
 # Installation
 
+If installation fails, please open an [issue](https://github.com/sakurai-youhei/qrrun/issues/new/choose) and paste the full error message.
+
 ## Linux
 
 Install from package repositories (recommended).


### PR DESCRIPTION
## Summary
- Add a troubleshooting note directly under Installation
- Link the word "issue" to the GitHub issue creation page

## Details
- Updated INSTALL.md to guide users to report install failures with full error output

## Why
- Makes it easier for users to report actionable installation failures
