### PR TITLE
Clarify ashell argv forwarding intent

### DIFF
--- a/internal/runtime/ashell.go
+++ b/internal/runtime/ashell.go
@@ -10,15 +10,11 @@ type AShell struct{}
 // QRCodeURL converts script argv to an a-Shell deep-link URL.
 // a-Shell uses the "ashell:" prefix (without "//").
 func (a *AShell) QRCodeURL(publicURL string, _ string, scriptArgv []string) string {
-	scriptArgs := scriptArgv
-	if len(scriptArgv) > 0 {
-		scriptArgs = scriptArgv[1:]
-	}
-
 	cmd := "curl -sSL " + shellSingleQuote(publicURL) + "|sh -s --"
-	if len(scriptArgs) > 0 {
-		escapedArgs := make([]string, 0, len(scriptArgs))
-		for _, arg := range scriptArgs {
+	if len(scriptArgv) > 1 {
+		// scriptArgv[0] is the local script path (or "-") and should not be passed to sh.
+		escapedArgs := make([]string, 0, len(scriptArgv)-1)
+		for _, arg := range scriptArgv[1:] {
 			escapedArgs = append(escapedArgs, shellEscapeWord(arg))
 		}
 		cmd += " " + strings.Join(escapedArgs, " ")


### PR DESCRIPTION
## Summary
- simplify `AShell.QRCodeURL` by removing an extra temporary argv variable
- keep the same behavior of forwarding only user arguments (`scriptArgv[1:]`)
- add an explanatory comment about why `scriptArgv[0]` is intentionally excluded for `sh -s`

## Why
- make the argument handling easier to read for non-Go experts
- preserve behavior while making the runtime-specific intent obvious

## Verification
- go test ./internal/runtime
- go test ./...
