### PR TITLE
Enable Python 2 in e2e-linux CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,32 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Setup Python
+      - name: Setup Python 3
+        id: setup-python3
         uses: actions/setup-python@v6
         with:
           python-version: "3.x"
+
+      - name: Setup Python 2
+        id: setup-python2
+        uses: actions/setup-python@v6
+        with:
+          python-version: "2.7"
+
+      - name: Ensure Python commands
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          ln -sf "${{ steps.setup-python2.outputs.python-path }}" \
+            "$HOME/.local/bin/python2"
+          ln -sf "${{ steps.setup-python3.outputs.python-path }}" \
+            "$HOME/.local/bin/python3"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+          export PATH="$HOME/.local/bin:$PATH"
+          python2 --version
+          python3 --version
 
       - name: Install cloudflared
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,11 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Setup Python 2
+      - name: Setup Python 2 compatible runtime
         id: setup-python2
         uses: actions/setup-python@v6
         with:
-          python-version: "2.7"
+          python-version: "pypy2.7"
 
       - name: Ensure Python commands
         shell: bash


### PR DESCRIPTION
## Summary
- add Python 2 setup to `e2e-linux` in CI
- keep Python 3 setup and expose both interpreters as `python2`/`python3`
- verify both versions in workflow before running E2E tests

## Why
- Pythonista2 runtime E2E paths require a `python2` command on Linux CI
- explicit interpreter wiring avoids runner image differences

## Validation
- `pre-commit run --files .github/workflows/ci.yml`