### PR TITLE
Switch ashell runtime support from sh to bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Flags:
   -v, --version                 version for qrrun
 
 Supported runtimes:
-	ashell        Shell (sh) script
+	ashell        Bash script
 	pythonista2   Python 2 script
 	pythonista3   Python 3 script
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,7 +61,7 @@ qrrun [flags] <script|-> [args...]
 - Supported runtimes: ashell, pythonista2, pythonista3
 - Supported QR error correction levels: L, M, Q, H
 - Default runtime is pythonista3, which supports arbitrary Python 3 script.
-- ashell runtime supports arbitrary sh script.
+- ashell runtime supports arbitrary bash script.
 
 ## Operational Tips
 - Use --print-url when validating URL generation in automation or tests.

--- a/cmd/qrrun/main.go
+++ b/cmd/qrrun/main.go
@@ -89,7 +89,7 @@ Examples:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}
 
 Supported runtimes:
-	ashell        Shell (sh) script
+	ashell        Bash script
 	pythonista2   Python 2 script
 	pythonista3   Python 3 script
 {{end}}`)

--- a/internal/runtime/ashell.go
+++ b/internal/runtime/ashell.go
@@ -10,9 +10,9 @@ type AShell struct{}
 // QRCodeURL converts script argv to an a-Shell deep-link URL.
 // a-Shell uses the "ashell:" prefix (without "//").
 func (a *AShell) QRCodeURL(publicURL string, _ string, scriptArgv []string) string {
-	cmd := "curl -sSL " + shellSingleQuote(publicURL) + "|sh -s --"
+	cmd := "curl -sSL " + shellSingleQuote(publicURL) + "|bash -s --"
 	if len(scriptArgv) > 1 {
-		// scriptArgv[0] is the local script path (or "-") and should not be passed to sh.
+		// scriptArgv[0] is the local script path (or "-") and should not be passed to bash.
 		escapedArgs := make([]string, 0, len(scriptArgv)-1)
 		for _, arg := range scriptArgv[1:] {
 			escapedArgs = append(escapedArgs, shellEscapeWord(arg))

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -35,7 +35,7 @@ func TestAshell_QRCodeURL(t *testing.T) {
 		t.Fatalf("ashell URL must use ashell: (without //), got %q", got)
 	}
 
-	wantDecoded := "curl -sSL 'https://example.com/run.sh?t=test-token'|sh -s -- arg1 arg2"
+	wantDecoded := "curl -sSL 'https://example.com/run.sh?t=test-token'|bash -s -- arg1 arg2"
 	payload := strings.TrimPrefix(got, "ashell:")
 	if payload != wantDecoded {
 		t.Fatalf("unexpected ashell payload: got %q, want %q", payload, wantDecoded)


### PR DESCRIPTION
## Summary
- change ashell runtime URL payload from `|sh -s --` to `|bash -s --`
- update runtime unit test expectations for the new bash payload
- align CLI help text and README supported runtime wording
- update `SKILL.md` runtime notes to match the actual behavior

## Why
- make ashell runtime behavior explicit and consistent with bash-based execution
- keep implementation, tests, help output, and documentation in sync

## Validation
- pre-commit checks during commit (`golangci-lint`, `go test`, `go vet`)
- `go test ./...`