### PR TITLE
Validate script argument propagation in E2E tests

### DIFF
--- a/test/e2e/base.py
+++ b/test/e2e/base.py
@@ -14,7 +14,13 @@ from uuid import uuid4
 
 
 class QRrunPrintURL(subprocess.Popen):
-    def __init__(self, transport: str, runtime: str, script: bytes) -> None:
+    def __init__(
+        self,
+        transport: str,
+        runtime: str,
+        script: bytes,
+        script_arguments: Sequence[str],
+    ) -> None:
         super().__init__(
             [
                 self.__qrrun(),
@@ -26,6 +32,7 @@ class QRrunPrintURL(subprocess.Popen):
                 runtime,
                 "--print-url",
                 "-",
+                *script_arguments,
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
@@ -100,6 +107,17 @@ class E2EPrintURLBase(TestCase, ABC):
     def script_output(self) -> bytes:
         return f"こんにちは, QRrun! {uuid4()} {printable}".encode("utf-8")
 
+    @cached_property
+    def script_arguments(self) -> list[str]:
+        return ["alpha", "two words", "", "quote'arg", "semi;colon"]
+
+    @cached_property
+    def expected_output(self) -> bytes:
+        out = bytearray(self.script_output)
+        for argument in self.script_arguments:
+            out.extend(f"\nARG:{argument}".encode("utf-8"))
+        return bytes(out)
+
     def test_validate_url_roundtrip(self) -> None:
         for command in [self.mock_runtime(), "cloudflared"]:
             if shutil.which(command) is None:
@@ -117,6 +135,7 @@ class E2EPrintURLBase(TestCase, ABC):
             self.transport(),
             self.runtime(),
             self.script(),
+            self.script_arguments,
         ) as qrrun:
             try:
                 url_line = qrrun.stdout_readline(timeout=10)
@@ -159,8 +178,8 @@ class E2EPrintURLBase(TestCase, ABC):
             f"expected {self.script()!r}, got {proc.stderr!r}",
         )
         self.assertEqual(
-            self.script_output,
+            self.expected_output,
             proc.stdout,
             "output mismatch: "
-            f"expected {self.script_output!r}, got {proc.stdout!r}",
+            f"expected {self.expected_output!r}, got {proc.stdout!r}",
         )

--- a/test/e2e/runtime/test_ashell.py
+++ b/test/e2e/runtime/test_ashell.py
@@ -26,9 +26,16 @@ class TestAShell(E2EPrintURLBase):
         return dedent(
             """\
             curl() {
-                RUNNER=`command curl "$@"`
-                echo "$RUNNER" >&2
-                echo "$RUNNER"
+                _runner_file="$(mktemp)"
+                command curl "$@" >"$_runner_file"
+                _status=$?
+                if [ "$_status" -ne 0 ]; then
+                    rm -f "$_runner_file"
+                    return "$_status"
+                fi
+                cat "$_runner_file" >&2
+                cat "$_runner_file"
+                rm -f "$_runner_file"
             }
             """
         ).encode("utf-8")

--- a/test/e2e/runtime/test_ashell.py
+++ b/test/e2e/runtime/test_ashell.py
@@ -16,6 +16,9 @@ class TestAShell(E2EPrintURLBase):
             f"""\
             #!/bin/sh
             echo {b64encode(self.script_output).decode("utf-8")} | base64 -d
+            for arg in "$@"; do
+                printf '\\nARG:%s' "$arg"
+            done
             """
         ).encode("utf-8")
 

--- a/test/e2e/runtime/test_pythonista2.py
+++ b/test/e2e/runtime/test_pythonista2.py
@@ -16,6 +16,9 @@ class TestPythonista2(E2EPrintURLBase):
             #!/usr/bin/env python2
             import sys
             sys.stdout.write({self.script_output!r})
+            for arg in sys.argv[1:]:
+                sys.stdout.write("\\nARG:")
+                sys.stdout.write(arg)
         """).encode("utf-8")
 
     def runner_preamble(self) -> bytes:

--- a/test/e2e/runtime/test_pythonista3.py
+++ b/test/e2e/runtime/test_pythonista3.py
@@ -17,6 +17,9 @@ class TestPythonista3(E2EPrintURLBase):
             #!/usr/bin/env python3
             import sys
             sys.stdout.buffer.write({self.script_output!r})
+            for arg in sys.argv[1:]:
+                sys.stdout.buffer.write(b"\\nARG:")
+                sys.stdout.buffer.write(arg.encode("utf-8"))
             """
         ).encode("utf-8")
 


### PR DESCRIPTION
## Summary
- pass explicit script arguments to `qrrun --print-url -` in E2E base flow
- add reusable expected-output builder that includes argument lines (`ARG:<value>`)
- update runtime scripts (`ashell`, `pythonista2`, `pythonista3`) to emit received args
- assert end-to-end output includes both script payload and propagated arguments

## Why
- existing E2E tests verified script payload delivery, but did not verify runtime argument propagation
- this adds direct runtime-level coverage that script args are passed through correctly

## Validation
- `make test-e2e` (ashell/pythonista3: pass, pythonista2: skipped when `python2` unavailable)
- pre-commit checks during commit (`ruff`, `ty`, `go test`, `go vet`)