### PR TITLE
Align package metadata across distribution formats

### DIFF
--- a/packaging/windows/qrrun.wxs
+++ b/packaging/windows/qrrun.wxs
@@ -5,7 +5,7 @@
     Name="qrrun"
     Language="1033"
     Version="$(var.ProductVersion)"
-    Manufacturer="qrrun maintainers"
+    Manufacturer="Youhei Sakurai"
     UpgradeCode="B1A2C8E2-3E4B-4F93-ABF7-D39C45FB0C6D">
     <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
     <MajorUpgrade DowngradeErrorMessage="A newer version of qrrun is already installed." />
@@ -15,6 +15,10 @@
     <Property Id="ApplicationFolderName" Value="qrrun" />
     <Property Id="WixUISupportPerUser" Value="1" />
     <Property Id="WixUISupportPerMachine" Value="1" />
+    <Property Id="ARPCONTACT" Value="Youhei Sakurai" />
+    <Property Id="ARPURLINFOABOUT" Value="https://github.com/sakurai-youhei/qrrun" />
+    <Property Id="ARPHELPLINK" Value="https://github.com/sakurai-youhei/qrrun/issues" />
+    <Property Id="ARPCOMMENTS" Value="qrrun tunnels local scripts and lets mobile runtimes execute them by scanning a QR code." />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="WixPerMachineFolder">

--- a/scripts/release_generate_homebrew_formula.sh
+++ b/scripts/release_generate_homebrew_formula.sh
@@ -5,6 +5,12 @@ VERSION="${VERSION:?VERSION is required}"
 REPO="${REPO:?REPO is required}"
 
 SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./release_package_metadata.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/release_package_metadata.sh"
+
 log() {
   echo "[${SCRIPT_NAME}] $*"
 }
@@ -21,8 +27,8 @@ require_tool sha256sum
 require_tool awk
 
 FORMULA_VERSION="${VERSION#v}"
-DARWIN_AMD64="qrrun_${VERSION}_darwin_amd64.tar.gz"
-DARWIN_ARM64="qrrun_${VERSION}_darwin_arm64.tar.gz"
+DARWIN_AMD64="${QRRUN_PACKAGE_NAME}_${VERSION}_darwin_amd64.tar.gz"
+DARWIN_ARM64="${QRRUN_PACKAGE_NAME}_${VERSION}_darwin_arm64.tar.gz"
 
 if [[ ! -f "dist/${DARWIN_AMD64}" ]]; then
   log "Missing release asset: dist/${DARWIN_AMD64}"
@@ -43,8 +49,9 @@ log "Generating Homebrew formula at dist/homebrew/qrrun.rb"
 
 cat >dist/homebrew/qrrun.rb <<EOF
 class Qrrun < Formula
-  desc "Prototype locally, run on your phone via a QR and a quick tunnel"
-  homepage "https://github.com/${REPO}"
+  desc "${QRRUN_PACKAGE_TAGLINE}"
+  homepage "${QRRUN_PACKAGE_HOMEPAGE}"
+  license "${QRRUN_PACKAGE_LICENSE}"
   version "${FORMULA_VERSION}"
 
   on_macos do
@@ -61,14 +68,14 @@ class Qrrun < Formula
 
   def install
     if Hardware::CPU.intel?
-      bin.install "qrrun_v#{version}_darwin_amd64" => "qrrun"
+      bin.install "${QRRUN_PACKAGE_NAME}_v#{version}_darwin_amd64" => "${QRRUN_PACKAGE_NAME}"
     else
-      bin.install "qrrun_v#{version}_darwin_arm64" => "qrrun"
+      bin.install "${QRRUN_PACKAGE_NAME}_v#{version}_darwin_arm64" => "${QRRUN_PACKAGE_NAME}"
     end
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/qrrun --version")
+    assert_match version.to_s, shell_output("#{bin}/${QRRUN_PACKAGE_NAME} --version")
   end
 end
 EOF

--- a/scripts/release_package_deb.sh
+++ b/scripts/release_package_deb.sh
@@ -6,6 +6,12 @@ GOARCH="${GOARCH:?GOARCH is required}"
 BIN="${BIN:?BIN is required}"
 
 SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./release_package_metadata.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/release_package_metadata.sh"
+
 log() {
   echo "[${SCRIPT_NAME}] $*"
 }
@@ -28,21 +34,23 @@ fi
 
 DEB_ARCH="${GOARCH}"
 DEB_VERSION="${VERSION#v}"
-DEB_BASE="qrrun_${DEB_VERSION}_${DEB_ARCH}"
+DEB_BASE="${QRRUN_PACKAGE_NAME}_${DEB_VERSION}_${DEB_ARCH}"
 PKG_ROOT="dist/${DEB_BASE}"
 
 log "Preparing Debian package layout: ${PKG_ROOT}"
 mkdir -p "${PKG_ROOT}/DEBIAN" "${PKG_ROOT}/usr/bin"
-install -m 0755 "dist/${BIN}" "${PKG_ROOT}/usr/bin/qrrun"
+install -m 0755 "dist/${BIN}" "${PKG_ROOT}/usr/bin/${QRRUN_PACKAGE_NAME}"
 
 cat >"${PKG_ROOT}/DEBIAN/control" <<EOF
-Package: qrrun
+Package: ${QRRUN_PACKAGE_NAME}
 Version: ${DEB_VERSION}
 Section: utils
 Priority: optional
 Architecture: ${DEB_ARCH}
-Maintainer: qrrun maintainers
-Description: Prototype locally, run on your phone via a QR and a quick tunnel
+Maintainer: ${QRRUN_PACKAGE_MAINTAINER}
+Homepage: ${QRRUN_PACKAGE_HOMEPAGE}
+Description: ${QRRUN_PACKAGE_TAGLINE}
+ ${QRRUN_PACKAGE_DESCRIPTION}
 EOF
 
 log "Building Debian package: dist/${DEB_BASE}.deb"

--- a/scripts/release_package_metadata.sh
+++ b/scripts/release_package_metadata.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+readonly QRRUN_PACKAGE_NAME="${QRRUN_PACKAGE_NAME:-qrrun}"
+readonly QRRUN_PACKAGE_MAINTAINER="${QRRUN_PACKAGE_MAINTAINER:-Youhei Sakurai}"
+readonly QRRUN_PACKAGE_SOURCE_REPO="${QRRUN_PACKAGE_SOURCE_REPO:-${REPO:-sakurai-youhei/qrrun}}"
+readonly QRRUN_PACKAGE_HOMEPAGE="${QRRUN_PACKAGE_HOMEPAGE:-https://github.com/${QRRUN_PACKAGE_SOURCE_REPO}}"
+readonly QRRUN_PACKAGE_LICENSE="${QRRUN_PACKAGE_LICENSE:-MIT}"
+readonly QRRUN_PACKAGE_TAGLINE="${QRRUN_PACKAGE_TAGLINE:-Prototype locally, run on your phone via a QR and a quick tunnel}"
+readonly QRRUN_PACKAGE_DESCRIPTION="${QRRUN_PACKAGE_DESCRIPTION:-qrrun tunnels local scripts and lets mobile runtimes execute them by scanning a QR code.}"

--- a/scripts/release_package_rpm.sh
+++ b/scripts/release_package_rpm.sh
@@ -6,6 +6,12 @@ GOARCH="${GOARCH:?GOARCH is required}"
 BIN="${BIN:?BIN is required}"
 
 SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./release_package_metadata.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/release_package_metadata.sh"
+
 log() {
   echo "[${SCRIPT_NAME}] $*"
 }
@@ -46,12 +52,15 @@ log "Building RPM package for ${RPM_ARCH} (version ${RPM_VERSION}-${RPM_RELEASE}
 fpm \
   -s dir \
   -t rpm \
-  -n qrrun \
+  -n "${QRRUN_PACKAGE_NAME}" \
   -v "${RPM_VERSION}" \
   --iteration "${RPM_RELEASE}" \
   --architecture "${RPM_ARCH}" \
-  --license MIT \
-  --description "Prototype locally, run on your phone via a QR and a quick tunnel." \
-  --package "dist/qrrun_${PKG_VERSION}_${RPM_ARCH}.rpm" \
-  "dist/${BIN}=/usr/bin/qrrun"
+  --maintainer "${QRRUN_PACKAGE_MAINTAINER}" \
+  --vendor "${QRRUN_PACKAGE_MAINTAINER}" \
+  --license "${QRRUN_PACKAGE_LICENSE}" \
+  --url "${QRRUN_PACKAGE_HOMEPAGE}" \
+  --description "${QRRUN_PACKAGE_DESCRIPTION}" \
+  --package "dist/${QRRUN_PACKAGE_NAME}_${PKG_VERSION}_${RPM_ARCH}.rpm" \
+  "dist/${BIN}=/usr/bin/${QRRUN_PACKAGE_NAME}"
 log "RPM package built successfully"


### PR DESCRIPTION
## Summary
- Align package metadata across deb, rpm, msi, and Homebrew packaging flows
- Add shared package metadata constants for consistency
- Improve MSI Add/Remove Programs metadata fields

## Changes
- Add scripts/release_package_metadata.sh
- Update Debian and RPM packaging scripts to consume shared metadata
- Update Homebrew formula generator metadata fields
- Update WiX metadata fields for MSI package information

Closes #141
