### PR TITLE
Include PR URL in release tracking issues

### DIFF
--- a/scripts/release_open_homebrew_tap_pr.sh
+++ b/scripts/release_open_homebrew_tap_pr.sh
@@ -27,6 +27,25 @@ gh_source() {
   GH_TOKEN="${QRRUN_GITHUB_TOKEN}" gh "$@"
 }
 
+write_issue_body() {
+  local output_file="$1"
+  local pr_url="$2"
+
+  cat >"${output_file}" <<EOF
+## Summary
+- Track homebrew-tap submission for qrrun ${VERSION_NO_V}
+
+## Release
+- qrrun release tag: ${VERSION}
+- source repo: https://github.com/${SOURCE_REPO}
+
+## Homebrew Tap
+- tap repo: https://github.com/${HOMEBREW_TAP_REPO}
+- target branch: ${BRANCH_NAME}
+- pull request: ${pr_url}
+EOF
+}
+
 for tool in gh git curl grep; do
   require_tool "${tool}"
 done
@@ -97,30 +116,23 @@ git commit -m "Update qrrun to ${VERSION}"
 git push --set-upstream origin "${BRANCH_NAME}"
 
 ISSUE_TITLE="Release: update Homebrew tap for qrrun ${VERSION_NO_V}"
+ISSUE_BODY_FILE="${TMP_DIR}/qrrun-homebrew-release-issue.md"
 EXISTING_ISSUE_NUMBER="$(gh_source issue list --repo "${SOURCE_REPO}" --state open --search "\"${ISSUE_TITLE}\" in:title" --json number --jq '.[0].number')"
 
 if [[ -n "${EXISTING_ISSUE_NUMBER}" && "${EXISTING_ISSUE_NUMBER}" != "null" ]]; then
+  ISSUE_NUMBER="${EXISTING_ISSUE_NUMBER}"
   ISSUE_URL="$(gh_source issue view "${EXISTING_ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --json url --jq '.url')"
 else
-  ISSUE_BODY_FILE="${TMP_DIR}/qrrun-homebrew-release-issue.md"
-  cat >"${ISSUE_BODY_FILE}" <<EOF
-## Summary
-- Track homebrew-tap submission for qrrun ${VERSION_NO_V}
-
-## Release
-- qrrun release tag: ${VERSION}
-- source repo: https://github.com/${SOURCE_REPO}
-
-## Homebrew Tap
-- tap repo: https://github.com/${HOMEBREW_TAP_REPO}
-- target branch: ${BRANCH_NAME}
-EOF
-
+  write_issue_body "${ISSUE_BODY_FILE}" "(pending)"
   ISSUE_URL="$(gh_source issue create --repo "${SOURCE_REPO}" --title "${ISSUE_TITLE}" --body-file "${ISSUE_BODY_FILE}")"
+  ISSUE_NUMBER="${ISSUE_URL##*/}"
 fi
 
 EXISTING_PR_NUMBER="$(gh_tap pr list --repo "${HOMEBREW_TAP_REPO}" --head "${TAP_OWNER}:${BRANCH_NAME}" --state open --json number --jq '.[0].number')"
 if [[ -n "${EXISTING_PR_NUMBER}" && "${EXISTING_PR_NUMBER}" != "null" ]]; then
+  PR_URL="$(gh_tap pr view --repo "${HOMEBREW_TAP_REPO}" "${EXISTING_PR_NUMBER}" --json url --jq '.url')"
+  write_issue_body "${ISSUE_BODY_FILE}" "${PR_URL}"
+  gh_source issue edit "${ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --body-file "${ISSUE_BODY_FILE}" >/dev/null
   gh_tap pr comment --repo "${HOMEBREW_TAP_REPO}" "${EXISTING_PR_NUMBER}" --body "qrrun tracking issue: ${ISSUE_URL}"
   log "Homebrew tap PR already exists: #${EXISTING_PR_NUMBER}"
   exit 0
@@ -138,11 +150,14 @@ cat >"${PR_BODY_FILE}" <<EOF
 - qrrun issue: ${ISSUE_URL}
 EOF
 
-gh_tap pr create \
+PR_URL="$(gh_tap pr create \
   --repo "${HOMEBREW_TAP_REPO}" \
   --base "${DEFAULT_BRANCH}" \
   --head "${TAP_OWNER}:${BRANCH_NAME}" \
   --title "Update qrrun to ${VERSION}" \
-  --body-file "${PR_BODY_FILE}"
+  --body-file "${PR_BODY_FILE}")"
 
-log "Homebrew tap PR created successfully"
+write_issue_body "${ISSUE_BODY_FILE}" "${PR_URL}"
+gh_source issue edit "${ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --body-file "${ISSUE_BODY_FILE}" >/dev/null
+
+log "Homebrew tap PR created successfully: ${PR_URL}"

--- a/scripts/release_open_linux_packages_pr.sh
+++ b/scripts/release_open_linux_packages_pr.sh
@@ -30,6 +30,25 @@ gh_source() {
   GH_TOKEN="${QRRUN_GITHUB_TOKEN}" gh "$@"
 }
 
+write_issue_body() {
+  local output_file="$1"
+  local pr_url="$2"
+
+  cat >"${output_file}" <<EOF
+## Summary
+- Track linux-packages submission for qrrun ${VERSION_NO_V}
+
+## Release
+- qrrun release tag: ${VERSION}
+- source repo: https://github.com/${SOURCE_REPO}
+
+## Linux Package Repositories
+- repo: https://github.com/${LINUX_PACKAGES_REPO}
+- target branch: ${BRANCH_NAME}
+- pull request: ${pr_url}
+EOF
+}
+
 SOURCE_OWNER="${SOURCE_REPO%%/*}"
 LINUX_PACKAGES_REPO="${LINUX_PACKAGES_REPO:-${SOURCE_OWNER}/linux-packages}"
 PACKAGES_OWNER="${LINUX_PACKAGES_REPO%%/*}"
@@ -173,30 +192,23 @@ git commit -m "Update qrrun Linux packages to ${VERSION}"
 git push --set-upstream origin "${BRANCH_NAME}"
 
 ISSUE_TITLE="Release: update Linux package repositories for qrrun ${VERSION_NO_V}"
+ISSUE_BODY_FILE="${TMP_DIR}/qrrun-linux-release-issue.md"
 EXISTING_ISSUE_NUMBER="$(gh_source issue list --repo "${SOURCE_REPO}" --state open --search "\"${ISSUE_TITLE}\" in:title" --json number --jq '.[0].number')"
 
 if [[ -n "${EXISTING_ISSUE_NUMBER}" && "${EXISTING_ISSUE_NUMBER}" != "null" ]]; then
+  ISSUE_NUMBER="${EXISTING_ISSUE_NUMBER}"
   ISSUE_URL="$(gh_source issue view "${EXISTING_ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --json url --jq '.url')"
 else
-  ISSUE_BODY_FILE="${TMP_DIR}/qrrun-linux-release-issue.md"
-  cat >"${ISSUE_BODY_FILE}" <<EOF
-## Summary
-- Track linux-packages submission for qrrun ${VERSION_NO_V}
-
-## Release
-- qrrun release tag: ${VERSION}
-- source repo: https://github.com/${SOURCE_REPO}
-
-## Linux Package Repositories
-- repo: https://github.com/${LINUX_PACKAGES_REPO}
-- target branch: ${BRANCH_NAME}
-EOF
-
+  write_issue_body "${ISSUE_BODY_FILE}" "(pending)"
   ISSUE_URL="$(gh_source issue create --repo "${SOURCE_REPO}" --title "${ISSUE_TITLE}" --body-file "${ISSUE_BODY_FILE}")"
+  ISSUE_NUMBER="${ISSUE_URL##*/}"
 fi
 
 EXISTING_PR_NUMBER="$(gh_packages pr list --repo "${LINUX_PACKAGES_REPO}" --head "${PACKAGES_OWNER}:${BRANCH_NAME}" --state open --json number --jq '.[0].number')"
 if [[ -n "${EXISTING_PR_NUMBER}" && "${EXISTING_PR_NUMBER}" != "null" ]]; then
+  PR_URL="$(gh_packages pr view --repo "${LINUX_PACKAGES_REPO}" "${EXISTING_PR_NUMBER}" --json url --jq '.url')"
+  write_issue_body "${ISSUE_BODY_FILE}" "${PR_URL}"
+  gh_source issue edit "${ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --body-file "${ISSUE_BODY_FILE}" >/dev/null
   gh_packages pr comment --repo "${LINUX_PACKAGES_REPO}" "${EXISTING_PR_NUMBER}" --body "qrrun tracking issue: ${ISSUE_URL}"
   log "Linux packages PR already exists: #${EXISTING_PR_NUMBER}"
   exit 0
@@ -219,11 +231,14 @@ cat >"${PR_BODY_FILE}" <<EOF
 - key base: https://raw.githubusercontent.com/${LINUX_PACKAGES_REPO}/main/keys
 EOF
 
-gh_packages pr create \
+PR_URL="$(gh_packages pr create \
   --repo "${LINUX_PACKAGES_REPO}" \
   --base "${DEFAULT_BRANCH}" \
   --head "${PACKAGES_OWNER}:${BRANCH_NAME}" \
   --title "Update qrrun Linux packages to ${VERSION}" \
-  --body-file "${PR_BODY_FILE}"
+  --body-file "${PR_BODY_FILE}")"
 
-log "Linux packages PR created successfully"
+write_issue_body "${ISSUE_BODY_FILE}" "${PR_URL}"
+gh_source issue edit "${ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --body-file "${ISSUE_BODY_FILE}" >/dev/null
+
+log "Linux packages PR created successfully: ${PR_URL}"

--- a/scripts/release_open_winget_pr.sh
+++ b/scripts/release_open_winget_pr.sh
@@ -27,6 +27,25 @@ gh_source() {
   GH_TOKEN="${QRRUN_GITHUB_TOKEN}" gh "$@"
 }
 
+write_issue_body() {
+  local output_file="$1"
+  local pr_url="$2"
+
+  cat >"${output_file}" <<EOF
+## Summary
+- Track winget-pkgs submission for ${PACKAGE_IDENTIFIER} ${VERSION_NO_V}
+
+## Release
+- qrrun release tag: ${VERSION}
+- source repo: https://github.com/${SOURCE_REPO}
+
+## winget-pkgs
+- package identifier: ${PACKAGE_IDENTIFIER}
+- target branch: ${BRANCH_NAME}
+- pull request: ${pr_url}
+EOF
+}
+
 for tool in gh git curl sha256sum awk date tr sed; do
   require_tool "${tool}"
 done
@@ -174,30 +193,23 @@ git commit -m "Add ${PACKAGE_IDENTIFIER} version ${VERSION_NO_V}"
 git push --set-upstream origin "${BRANCH_NAME}"
 
 ISSUE_TITLE="Release: submit ${PACKAGE_IDENTIFIER} ${VERSION_NO_V} to winget-pkgs"
+ISSUE_BODY_FILE="${TMP_DIR}/qrrun-winget-release-issue.md"
 EXISTING_ISSUE_NUMBER="$(gh_source issue list --repo "${SOURCE_REPO}" --state open --search "\"${ISSUE_TITLE}\" in:title" --json number --jq '.[0].number')"
 
 if [[ -n "${EXISTING_ISSUE_NUMBER}" && "${EXISTING_ISSUE_NUMBER}" != "null" ]]; then
+  ISSUE_NUMBER="${EXISTING_ISSUE_NUMBER}"
   ISSUE_URL="$(gh_source issue view "${EXISTING_ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --json url --jq '.url')"
 else
-  ISSUE_BODY_FILE="${TMP_DIR}/qrrun-winget-release-issue.md"
-  cat >"${ISSUE_BODY_FILE}" <<EOF
-## Summary
-- Track winget-pkgs submission for ${PACKAGE_IDENTIFIER} ${VERSION_NO_V}
-
-## Release
-- qrrun release tag: ${VERSION}
-- source repo: https://github.com/${SOURCE_REPO}
-
-## winget-pkgs
-- package identifier: ${PACKAGE_IDENTIFIER}
-- target branch: ${BRANCH_NAME}
-EOF
-
+  write_issue_body "${ISSUE_BODY_FILE}" "(pending)"
   ISSUE_URL="$(gh_source issue create --repo "${SOURCE_REPO}" --title "${ISSUE_TITLE}" --body-file "${ISSUE_BODY_FILE}")"
+  ISSUE_NUMBER="${ISSUE_URL##*/}"
 fi
 
 EXISTING_PR_NUMBER="$(gh_winget pr list --repo "${WINGET_UPSTREAM_REPO}" --head "sakurai-youhei:${BRANCH_NAME}" --state open --json number --jq '.[0].number')"
 if [[ -n "${EXISTING_PR_NUMBER}" && "${EXISTING_PR_NUMBER}" != "null" ]]; then
+  PR_URL="$(gh_winget pr view --repo "${WINGET_UPSTREAM_REPO}" "${EXISTING_PR_NUMBER}" --json url --jq '.url')"
+  write_issue_body "${ISSUE_BODY_FILE}" "${PR_URL}"
+  gh_source issue edit "${ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --body-file "${ISSUE_BODY_FILE}" >/dev/null
   log "winget-pkgs PR already exists: #${EXISTING_PR_NUMBER}"
   exit 0
 fi
@@ -214,6 +226,9 @@ NEW_PR_URL="$(gh_winget pr create \
   --head "sakurai-youhei:${BRANCH_NAME}" \
   --title "Add ${PACKAGE_IDENTIFIER} version ${VERSION_NO_V}" \
   --body-file "${PR_TEMPLATE_FILE}")"
+
+write_issue_body "${ISSUE_BODY_FILE}" "${NEW_PR_URL}"
+gh_source issue edit "${ISSUE_NUMBER}" --repo "${SOURCE_REPO}" --body-file "${ISSUE_BODY_FILE}" >/dev/null
 
 NEW_PR_NUMBER="${NEW_PR_URL##*/}"
 if [[ ! "${NEW_PR_NUMBER}" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
- Include pull request URL in release tracking issues created by release automation scripts.
- Apply the same behavior to Homebrew tap, Linux packages, and winget release flows.

## Changes
- Add `write_issue_body` helper in each release PR script.
- Add `pull request: <PR_URL>` field in release tracking issue body.
- Update issue body after PR URL is known for both new PR creation and existing PR detection paths.

## Updated Scripts
- `scripts/release_open_homebrew_tap_pr.sh`
- `scripts/release_open_linux_packages_pr.sh`
- `scripts/release_open_winget_pr.sh`

## Validation
- `bash -n scripts/release_open_homebrew_tap_pr.sh scripts/release_open_linux_packages_pr.sh scripts/release_open_winget_pr.sh`
